### PR TITLE
feat: enrich MCP error messages with schema discovery hints

### DIFF
--- a/src/infrahub_mcp/resources/schema.py
+++ b/src/infrahub_mcp/resources/schema.py
@@ -1,14 +1,13 @@
 """Schema resources for the Infrahub MCP server."""
 
-import asyncio
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import toon
 from fastmcp import Context, FastMCP
 from infrahub_sdk.exceptions import BranchNotFoundError, SchemaNotFoundError
 
-from infrahub_mcp.constants import NAMESPACES_INTERNAL, schema_attribute_type_mapping
+from infrahub_mcp.schema import get_schema_catalog, get_schema_detail
 
 if TYPE_CHECKING:
     from infrahub_sdk.client import InfrahubClient
@@ -31,13 +30,10 @@ async def schema_catalog(ctx: Context) -> str:
     client: InfrahubClient = ctx.request_context.lifespan_context.client  # type: ignore[union-attr]
 
     try:
-        all_schemas = await client.schema.all()
+        result = await get_schema_catalog(client)
     except BranchNotFoundError as exc:
         return json.dumps({"error": str(exc)}, separators=(",", ":"))
 
-    result = {
-        kind: node.label or kind for kind, node in all_schemas.items() if node.namespace not in NAMESPACES_INTERNAL
-    }
     return json.dumps(result, separators=(",", ":"))
 
 
@@ -58,7 +54,7 @@ async def schema_kind_detail(kind: str, ctx: Context) -> str:
     client: InfrahubClient = ctx.request_context.lifespan_context.client  # type: ignore[union-attr]
 
     try:
-        schema = await client.schema.get(kind=kind)
+        payload = await get_schema_detail(client, kind=kind)
     except SchemaNotFoundError:
         return json.dumps(
             {
@@ -68,50 +64,6 @@ async def schema_kind_detail(kind: str, ctx: Context) -> str:
             separators=(",", ":"),
         )
 
-    # Build filters as list-of-dicts so TOON can tabularise them
-    filter_list: list[dict[str, str]] = [
-        {
-            "filter": f"{attr.name}__value",
-            "type": schema_attribute_type_mapping.get(attr.kind, "String"),
-        }
-        for attr in schema.attributes
-    ]
-
-    # Fetch peer schemas in parallel, deduplicating repeated peer kinds
-    unique_peer_kinds: list[str] = list(dict.fromkeys(rel.peer for rel in schema.relationships))
-
-    async def _fetch_peer(peer_kind: str) -> tuple[str, Any]:
-        try:
-            return peer_kind, await client.schema.get(kind=peer_kind)
-        except SchemaNotFoundError:
-            return peer_kind, None
-
-    peer_results = await asyncio.gather(*[_fetch_peer(pk) for pk in unique_peer_kinds])
-    peer_schemas: dict[str, Any] = {pk: s for pk, s in peer_results if s is not None}
-
-    for rel in schema.relationships:
-        rel_schema = peer_schemas.get(rel.peer)
-        if rel_schema is None:
-            continue
-        filter_list.extend(
-            {
-                "filter": f"{rel.name}__{attr.name}__value",
-                "type": schema_attribute_type_mapping.get(attr.kind, "String"),
-            }
-            for attr in rel_schema.attributes
-        )
-
-    payload: dict[str, Any] = {
-        "kind": schema.kind,
-        "label": schema.label,
-        "namespace": schema.namespace,
-        "attributes": [{"name": a.name, "kind": a.kind, "optional": a.optional} for a in schema.attributes],
-        "relationships": [
-            {"name": r.name, "peer": r.peer, "cardinality": r.cardinality, "optional": r.optional}
-            for r in schema.relationships
-        ],
-        "filters": filter_list,
-    }
     return toon.encode(payload)
 
 

--- a/src/infrahub_mcp/schema.py
+++ b/src/infrahub_mcp/schema.py
@@ -1,0 +1,113 @@
+"""Shared schema helpers for the Infrahub MCP server.
+
+Both MCP resources and MCP tools import from this module to avoid
+duplicating schema-fetching logic.
+"""
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from infrahub_sdk.exceptions import SchemaNotFoundError
+
+from infrahub_mcp.constants import NAMESPACES_INTERNAL, schema_attribute_type_mapping
+
+if TYPE_CHECKING:
+    from infrahub_sdk.client import InfrahubClient
+
+
+async def get_schema_catalog(client: "InfrahubClient", branch: str | None = None) -> dict[str, str]:
+    """Return a kind-to-label mapping of all non-internal schema kinds.
+
+    Args:
+        client: Infrahub SDK client.
+        branch: Optional branch to query. Defaults to the default branch.
+
+    Returns:
+        Dict mapping kind names to human-readable labels.
+    """
+    all_schemas = await client.schema.all(branch=branch)
+    return {
+        kind: node.label or kind
+        for kind, node in all_schemas.items()
+        if node.namespace not in NAMESPACES_INTERNAL
+    }
+
+
+async def get_schema_detail(client: "InfrahubClient", kind: str, branch: str | None = None) -> dict[str, Any]:
+    """Return full schema detail for a specific kind.
+
+    Includes attributes, relationships, and the complete filter map
+    (with filters derived from related peer schemas fetched in parallel).
+
+    Args:
+        client: Infrahub SDK client.
+        kind: Schema kind to retrieve.
+        branch: Optional branch to query.
+
+    Returns:
+        Dict with keys: kind, label, namespace, attributes, relationships, filters.
+
+    Raises:
+        SchemaNotFoundError: If the kind does not exist.
+    """
+    schema = await client.schema.get(kind=kind, branch=branch)
+
+    filter_list: list[dict[str, str]] = [
+        {
+            "filter": f"{attr.name}__value",
+            "type": schema_attribute_type_mapping.get(attr.kind, "String"),
+        }
+        for attr in schema.attributes
+    ]
+
+    unique_peer_kinds: list[str] = list(dict.fromkeys(rel.peer for rel in schema.relationships))
+
+    async def _fetch_peer(peer_kind: str) -> tuple[str, Any]:
+        try:
+            return peer_kind, await client.schema.get(kind=peer_kind, branch=branch)
+        except SchemaNotFoundError:
+            return peer_kind, None
+
+    peer_results = await asyncio.gather(*[_fetch_peer(pk) for pk in unique_peer_kinds])
+    peer_schemas: dict[str, Any] = {pk: s for pk, s in peer_results if s is not None}
+
+    for rel in schema.relationships:
+        rel_schema = peer_schemas.get(rel.peer)
+        if rel_schema is None:
+            continue
+        filter_list.extend(
+            {
+                "filter": f"{rel.name}__{attr.name}__value",
+                "type": schema_attribute_type_mapping.get(attr.kind, "String"),
+            }
+            for attr in rel_schema.attributes
+        )
+
+    return {
+        "kind": schema.kind,
+        "label": schema.label,
+        "namespace": schema.namespace,
+        "attributes": [{"name": a.name, "kind": a.kind, "optional": a.optional} for a in schema.attributes],
+        "relationships": [
+            {"name": r.name, "peer": r.peer, "cardinality": r.cardinality, "optional": r.optional}
+            for r in schema.relationships
+        ],
+        "filters": filter_list,
+    }
+
+
+async def get_valid_kinds_summary(client: "InfrahubClient", branch: str | None = None) -> str:
+    """Return a compact string listing all valid non-internal kinds.
+
+    Intended for inclusion in error messages so agents can self-correct
+    without a second tool call.
+
+    Args:
+        client: Infrahub SDK client.
+        branch: Optional branch to query.
+
+    Returns:
+        String like "Valid kinds: InfraDevice, InfraInterfaceL3, ..."
+    """
+    catalog = await get_schema_catalog(client, branch=branch)
+    return "Valid kinds: " + ", ".join(sorted(catalog.keys()))

--- a/src/infrahub_mcp/server.py
+++ b/src/infrahub_mcp/server.py
@@ -57,20 +57,25 @@ Structured arrays (schema details, node attribute results) are encoded in
 TOON declares field names once in a header, then lists rows of values.
 Treat TOON exactly like a table: the header is the column spec, each indented row is one record.
 
-## Available context (resources — read before tool calls)
+## Schema discovery (always do this first)
 
-| Resource | What it contains |
-|---|---|
-| `infrahub://schema` | All node kinds available in this instance |
-| `infrahub://schema/{kind}` | Full schema + filter map for a specific kind |
-| `infrahub://graphql-schema` | Complete GraphQL SDL for advanced queries |
-| `infrahub://branches` | All branches, including your active session branch |
+Read the ``infrahub://schema`` resource to discover available kinds before querying.
+If your client does not support MCP resources, call the ``get_schema`` tool instead —
+it provides the same data.
 
-Read these resources first to avoid guessing kind names or filter keys.
+| Resource | Tool equivalent | What it contains |
+|---|---|---|
+| `infrahub://schema` | `get_schema()` | All node kinds available in this instance |
+| `infrahub://schema/{kind}` | `get_schema(kind='...')` | Full schema + filter map for a specific kind |
+| `infrahub://graphql-schema` | *(none)* | Complete GraphQL SDL for advanced queries |
+| `infrahub://branches` | *(none)* | All branches, including your active session branch |
+
+Never guess kind names or filter keys — discover them first.
 
 ## Available tools
 
 ### Read
+- **`get_schema`** — discover available kinds and their attributes/filters. Use when resources are not available.
 - **`get_nodes`** — retrieve objects of a given kind, with optional filters. Pass `include_attributes=True` for full attribute data.
 - **`search_nodes`** — find nodes by partial name match.
 - **`query_graphql`** — execute any GraphQL query or mutation.

--- a/src/infrahub_mcp/server.py
+++ b/src/infrahub_mcp/server.py
@@ -10,6 +10,7 @@ from infrahub_mcp.resources.branches import mcp as branches_resources_mcp
 from infrahub_mcp.resources.schema import mcp as schema_resources_mcp
 from infrahub_mcp.tools.gql import mcp as graphql_mcp
 from infrahub_mcp.tools.nodes import mcp as nodes_mcp
+from infrahub_mcp.tools.schema import mcp as schema_tools_mcp
 from infrahub_mcp.tools.write import mcp as write_mcp
 from infrahub_mcp.utils import AppContext
 
@@ -105,3 +106,4 @@ mcp.mount(prompts_mcp)
 mcp.mount(graphql_mcp)
 mcp.mount(nodes_mcp)
 mcp.mount(write_mcp)
+mcp.mount(schema_tools_mcp)

--- a/src/infrahub_mcp/tools/gql.py
+++ b/src/infrahub_mcp/tools/gql.py
@@ -41,6 +41,13 @@ async def query_graphql(
     try:
         data = await client.execute_graphql(query=query, branch_name=branch)
     except GraphQLError as exc:
-        await _log_and_raise_error(ctx, exc)
+        await _log_and_raise_error(
+            ctx,
+            exc,
+            remediation=(
+                "Call get_schema() to list valid kinds, or "
+                "get_schema(kind='...') to see attributes and filters."
+            ),
+        )
 
     return data

--- a/src/infrahub_mcp/tools/gql.py
+++ b/src/infrahub_mcp/tools/gql.py
@@ -29,6 +29,10 @@ async def query_graphql(
 ) -> dict[str, Any]:
     """Execute a GraphQL query against Infrahub.
 
+    To discover available kinds and their attributes, read the ``infrahub://schema``
+    resource. If your client does not support MCP resources, call the ``get_schema``
+    tool instead. For the full GraphQL SDL, read ``infrahub://graphql-schema``.
+
     Parameters:
         query: GraphQL query to execute.
         branch: Branch to execute the query against. Defaults to None (uses default branch).

--- a/src/infrahub_mcp/tools/nodes.py
+++ b/src/infrahub_mcp/tools/nodes.py
@@ -133,8 +133,10 @@ async def get_nodes(  # pylint: disable=too-many-arguments,too-many-positional-a
 ) -> list[str] | str:
     """Retrieve objects of a specific kind from Infrahub.
 
-    To discover available kinds read the resource ``infrahub://schema``.
-    To discover available filters for a kind read ``infrahub://schema/{kind}``.
+    To discover available kinds, read the ``infrahub://schema`` resource.
+    If your client does not support MCP resources, call the ``get_schema`` tool instead.
+    To discover available filters for a kind, read ``infrahub://schema/{kind}``
+    or call ``get_schema(kind='...')``.
 
     Args:
         kind: Kind of the objects to retrieve.
@@ -233,6 +235,9 @@ async def search_nodes(
 
     A convenience wrapper around get_nodes with ``partial_match=True`` and a ``name__value``
     filter. Use when you need to find a node without knowing its exact name.
+
+    To discover available kinds, read the ``infrahub://schema`` resource.
+    If your client does not support MCP resources, call the ``get_schema`` tool instead.
 
     Args:
         query: Partial name string to search for.

--- a/src/infrahub_mcp/tools/nodes.py
+++ b/src/infrahub_mcp/tools/nodes.py
@@ -9,6 +9,7 @@ from infrahub_sdk.types import Order
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from infrahub_mcp.schema import get_valid_kinds_summary
 from infrahub_mcp.utils import _log_and_raise_error, convert_node_to_dict
 
 if TYPE_CHECKING:
@@ -108,10 +109,11 @@ async def get_nodes(  # pylint: disable=too-many-arguments,too-many-positional-a
     try:
         schema = await client.schema.get(kind=kind, branch=branch)
     except SchemaNotFoundError:
+        valid = await get_valid_kinds_summary(client, branch=branch)
         await _log_and_raise_error(
             ctx=ctx,
             error=f"Schema not found for kind: {kind}.",
-            remediation="Read infrahub://schema to list available kinds.",
+            remediation=f"{valid}\nCall get_schema() for details on any kind.",
         )
 
     if filters:
@@ -210,10 +212,11 @@ async def search_nodes(
     try:
         schema = await client.schema.get(kind=kind, branch=branch)
     except SchemaNotFoundError:
+        valid = await get_valid_kinds_summary(client, branch=branch)
         await _log_and_raise_error(
             ctx=ctx,
             error=f"Schema not found for kind: {kind}.",
-            remediation="Read infrahub://schema to list available kinds.",
+            remediation=f"{valid}\nCall get_schema() for details on any kind.",
         )
 
     try:

--- a/src/infrahub_mcp/tools/nodes.py
+++ b/src/infrahub_mcp/tools/nodes.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 import toon
 from fastmcp import Context, FastMCP
 from infrahub_sdk.exceptions import GraphQLError, SchemaNotFoundError
+from infrahub_sdk.schema import MainSchemaTypes
 from infrahub_sdk.types import Order
 from mcp.types import ToolAnnotations
 from pydantic import Field
@@ -38,6 +39,56 @@ _RESERVED_FILTER_KEYS: frozenset[str] = frozenset(
         "include_metadata",
     }
 )
+
+
+async def _validate_filters(  # noqa: PLR0913, PLR0917
+    ctx: Context,
+    client: "InfrahubClient",
+    schema: MainSchemaTypes,
+    kind: str,
+    branch: str | None,
+    filters: dict[str, Any],
+) -> None:
+    """Validate filter keys against the schema and raise an error for unknown keys.
+
+    Args:
+        ctx: MCP context for logging and error reporting.
+        client: Infrahub SDK client.
+        schema: Schema for the kind being queried.
+        kind: Kind name (used in error messages).
+        branch: Branch name.
+        filters: Filter dict provided by the caller.
+
+    Raises:
+        RuntimeError: Via ``_log_and_raise_error`` when unknown filter keys are found.
+    """
+    reserved = set(filters) & _RESERVED_FILTER_KEYS
+    if reserved:
+        await _log_and_raise_error(
+            ctx=ctx,
+            error=f"Filters contain reserved key(s): {sorted(reserved)}.",
+            remediation=(f"Remove reserved key(s) and check infrahub://schema/{kind} for valid filter names."),
+        )
+
+    # Build the valid filter set from the schema (same logic as schema detail)
+    valid_filters: set[str] = {f"{attr.name}__value" for attr in schema.attributes}
+    for rel in schema.relationships:
+        try:
+            rel_schema = await client.schema.get(kind=rel.peer, branch=branch)
+            valid_filters.update(f"{rel.name}__{attr.name}__value" for attr in rel_schema.attributes)
+        except SchemaNotFoundError:
+            continue
+    invalid_keys = set(filters.keys()) - valid_filters - _RESERVED_FILTER_KEYS
+    if invalid_keys:
+        sorted_valid = ", ".join(sorted(valid_filters))
+        await _log_and_raise_error(
+            ctx=ctx,
+            error=f"Invalid filter(s) for {kind}: {sorted(invalid_keys)}.",
+            remediation=(
+                f"Valid filters for {kind}: {sorted_valid}\n"
+                f"Call get_schema(kind='{kind}') for the full schema."
+            ),
+        )
 
 
 @mcp.tool(tags={"nodes", "retrieve"}, annotations=ToolAnnotations(readOnlyHint=True))
@@ -117,13 +168,9 @@ async def get_nodes(  # pylint: disable=too-many-arguments,too-many-positional-a
         )
 
     if filters:
-        reserved = set(filters) & _RESERVED_FILTER_KEYS
-        if reserved:
-            await _log_and_raise_error(
-                ctx=ctx,
-                error=f"Filters contain reserved key(s): {sorted(reserved)}.",
-                remediation=(f"Remove reserved key(s) and check infrahub://schema/{kind} for valid filter names."),
-            )
+        await _validate_filters(
+            ctx=ctx, client=client, schema=schema, kind=kind, branch=branch, filters=filters
+        )
 
     try:
         kwargs: dict[str, Any] = {

--- a/src/infrahub_mcp/tools/schema.py
+++ b/src/infrahub_mcp/tools/schema.py
@@ -1,0 +1,69 @@
+"""Schema discovery tool for the Infrahub MCP server."""
+
+import json
+from typing import TYPE_CHECKING, Annotated
+
+import toon
+from fastmcp import Context, FastMCP
+from infrahub_sdk.exceptions import SchemaNotFoundError
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from infrahub_mcp.schema import get_schema_catalog, get_schema_detail, get_valid_kinds_summary
+from infrahub_mcp.utils import _log_and_raise_error
+
+if TYPE_CHECKING:
+    from infrahub_sdk.client import InfrahubClient
+
+mcp: FastMCP = FastMCP(name="Infrahub Schema")
+
+
+@mcp.tool(tags={"schema", "retrieve"}, annotations=ToolAnnotations(readOnlyHint=True))
+async def get_schema(
+    ctx: Context,
+    kind: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Kind to get detail for. Omit to list all available kinds."
+            ),
+        ),
+    ] = None,
+    branch: Annotated[
+        str | None,
+        Field(default=None, description="Branch to query. Defaults to the default branch."),
+    ] = None,
+) -> str:
+    """Discover available schema kinds and their structure in Infrahub.
+
+    Call without arguments to list all available kinds.
+    Call with a ``kind`` to see its attributes, relationships, and valid filter keys.
+
+    Prefer reading the ``infrahub://schema`` resource if your client supports
+    MCP resources — this tool provides the same data for clients that don't.
+
+    Args:
+        kind: Optional kind to get detail for. Omit to list all kinds.
+        branch: Branch to query. Defaults to the default branch.
+
+    Returns:
+        JSON catalog (no kind) or TOON-encoded schema detail (with kind).
+    """
+    client: InfrahubClient = ctx.request_context.lifespan_context.client  # type: ignore[union-attr]
+
+    if kind is None:
+        catalog = await get_schema_catalog(client, branch=branch)
+        return json.dumps(catalog, separators=(",", ":"))
+
+    try:
+        detail = await get_schema_detail(client, kind=kind, branch=branch)
+    except SchemaNotFoundError:
+        valid = await get_valid_kinds_summary(client, branch=branch)
+        await _log_and_raise_error(
+            ctx=ctx,
+            error=f"Schema not found for kind: {kind}.",
+            remediation=f"{valid}\nCall get_schema() for the full catalog, or get_schema(kind='<kind>') for details.",
+        )
+
+    return toon.encode(detail)

--- a/src/infrahub_mcp/tools/write.py
+++ b/src/infrahub_mcp/tools/write.py
@@ -61,6 +61,9 @@ async def node_upsert(  # pylint: disable=too-many-locals
     The session branch is auto-created on the first write of the session
     (``mcp/session-YYYYMMDD-<hex>``). Use ``propose_changes`` to open a
     review once your changes are ready.
+    To discover available kinds and attributes, read the ``infrahub://schema``
+    resource. If your client does not support MCP resources, call the
+    ``get_schema`` tool instead.
 
     - **Create**: omit both ``id`` and ``hfid``.
     - **Update**: supply either ``id`` or ``hfid`` to identify the target node.
@@ -158,6 +161,9 @@ async def node_delete(
 
     The deletion is applied to the session branch only and is not visible on the
     default branch until a proposed change is merged.
+    To discover available kinds, read the ``infrahub://schema`` resource.
+    If your client does not support MCP resources, call the ``get_schema``
+    tool instead.
 
     Parameters:
         kind: Kind of the node.

--- a/src/infrahub_mcp/tools/write.py
+++ b/src/infrahub_mcp/tools/write.py
@@ -8,6 +8,7 @@ from infrahub_sdk.exceptions import GraphQLError, NodeNotFoundError, SchemaNotFo
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from infrahub_mcp.schema import get_valid_kinds_summary
 from infrahub_mcp.utils import _log_and_raise_error, get_or_create_session_branch
 
 if TYPE_CHECKING:
@@ -83,10 +84,11 @@ async def node_upsert(  # pylint: disable=too-many-locals
     try:
         schema = await client.schema.get(kind=kind, branch=session_branch)
     except SchemaNotFoundError:
+        valid = await get_valid_kinds_summary(client, branch=session_branch)
         await _log_and_raise_error(
             ctx=ctx,
             error=f"Schema not found for kind: {kind}.",
-            remediation="Read infrahub://schema to list available kinds.",
+            remediation=f"{valid}\nCall get_schema() for details on any kind.",
         )
 
     sdk_data = {key: {"value": value} for key, value in data.items()}
@@ -178,10 +180,11 @@ async def node_delete(
     try:
         schema = await client.schema.get(kind=kind, branch=session_branch)
     except SchemaNotFoundError:
+        valid = await get_valid_kinds_summary(client, branch=session_branch)
         await _log_and_raise_error(
             ctx=ctx,
             error=f"Schema not found for kind: {kind}.",
-            remediation="Read infrahub://schema to list available kinds.",
+            remediation=f"{valid}\nCall get_schema() for details on any kind.",
         )
 
     try:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -79,3 +79,51 @@ async def test_get_nodes_unknown_kind() -> None:
         assert result.is_error is True
         text = result.content[0].text  # type: ignore[union-attr]
         assert "Remediation:" in text
+
+
+async def test_get_schema_tool_catalog() -> None:
+    """get_schema with no kind returns the same catalog as the resource."""
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_schema", {})
+        assert result.is_error is False
+        data = json.loads(result.data)
+        assert isinstance(data, dict)
+        assert "LocationSite" in data
+        # Internal kinds should be filtered out
+        for key in data:
+            assert not key.startswith(("Internal", "Profile", "Template"))
+
+
+async def test_get_schema_tool_kind_detail() -> None:
+    """get_schema with a kind returns the same detail as the resource."""
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_schema", {"kind": "LocationSite"})
+        assert result.is_error is False
+        data = toon.decode(result.data)
+        assert data["kind"] == "LocationSite"
+        assert "attributes" in data
+        assert "relationships" in data
+        assert "filters" in data
+        assert any(d.get("filter") == "name__value" for d in data["filters"])
+
+
+async def test_get_schema_tool_invalid_kind() -> None:
+    """get_schema with invalid kind returns error with valid kinds list."""
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_schema", {"kind": "DoesNotExist"}, raise_on_error=False)
+        assert result.is_error is True
+        text = result.content[0].text  # type: ignore[union-attr]
+        assert "DoesNotExist" in text
+        assert "Valid kinds:" in text
+        assert "get_schema()" in text
+
+
+async def test_get_schema_tool_matches_resource() -> None:
+    """get_schema tool output matches infrahub://schema resource output."""
+    async with Client(mcp) as client:
+        # Compare catalog
+        resource = await client.read_resource("infrahub://schema")
+        resource_data = json.loads(resource[0].text)  # type: ignore[attr-defined]
+        tool_result = await client.call_tool("get_schema", {})
+        tool_data = json.loads(tool_result.data)
+        assert resource_data == tool_data

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -178,3 +178,16 @@ async def test_get_nodes_invalid_filter_includes_valid_filters() -> None:
         assert "Valid filters for LocationSite:" in text
         assert "name__value" in text
         assert "get_schema(kind='LocationSite')" in text
+
+
+async def test_query_graphql_error_includes_schema_hint() -> None:
+    """query_graphql error includes hint about get_schema tool."""
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "query_graphql",
+            {"query": "{ NonExistentKind { edges { node { name { value } } } } }"},
+            raise_on_error=False,
+        )
+        assert result.is_error is True
+        text = result.content[0].text  # type: ignore[union-attr]
+        assert "get_schema()" in text

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -127,3 +127,38 @@ async def test_get_schema_tool_matches_resource() -> None:
         tool_result = await client.call_tool("get_schema", {})
         tool_data = json.loads(tool_result.data)
         assert resource_data == tool_data
+
+
+async def test_get_nodes_unknown_kind_includes_valid_kinds() -> None:
+    """get_nodes with invalid kind error includes the list of valid kinds."""
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_nodes", {"kind": "DoesNotExist"}, raise_on_error=False)
+        assert result.is_error is True
+        text = result.content[0].text  # type: ignore[union-attr]
+        assert "Valid kinds:" in text
+        assert "LocationSite" in text
+        assert "get_schema()" in text
+
+
+async def test_search_nodes_unknown_kind_includes_valid_kinds() -> None:
+    """search_nodes with invalid kind error includes the list of valid kinds."""
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "search_nodes", {"query": "test", "kind": "DoesNotExist"}, raise_on_error=False
+        )
+        assert result.is_error is True
+        text = result.content[0].text  # type: ignore[union-attr]
+        assert "Valid kinds:" in text
+        assert "get_schema()" in text
+
+
+async def test_node_upsert_unknown_kind_includes_valid_kinds() -> None:
+    """node_upsert with invalid kind error includes the list of valid kinds."""
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "node_upsert", {"kind": "DoesNotExist", "data": {"name": "test"}}, raise_on_error=False
+        )
+        assert result.is_error is True
+        text = result.content[0].text  # type: ignore[union-attr]
+        assert "Valid kinds:" in text
+        assert "get_schema()" in text

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -162,3 +162,19 @@ async def test_node_upsert_unknown_kind_includes_valid_kinds() -> None:
         text = result.content[0].text  # type: ignore[union-attr]
         assert "Valid kinds:" in text
         assert "get_schema()" in text
+
+
+async def test_get_nodes_invalid_filter_includes_valid_filters() -> None:
+    """get_nodes with invalid filter key returns error with valid filters for that kind."""
+    async with Client(mcp) as client:
+        result = await client.call_tool(
+            "get_nodes",
+            {"kind": "LocationSite", "filters": {"interface__name": "eth0"}},
+            raise_on_error=False,
+        )
+        assert result.is_error is True
+        text = result.content[0].text  # type: ignore[union-attr]
+        assert "interface__name" in text
+        assert "Valid filters for LocationSite:" in text
+        assert "name__value" in text
+        assert "get_schema(kind='LocationSite')" in text


### PR DESCRIPTION
When an AI agent sends a wrong `kind` or invalid filter keys, the error alone isn't enough — the agent has to make another round-trip just to figure out what *is* valid. This PR makes every error self-correcting by embedding the valid options directly in the error response.

A shared `schema.py` module now backs both MCP resources and a new `get_schema` tool (for clients that don't support MCP resources), eliminating duplicated schema-fetching logic. On top of that, `SchemaNotFoundError` messages now list all valid kinds, filter validation rejects unknown keys with the full valid-filter set, and `query_graphql` errors point the agent toward `get_schema()` for discovery.

```python
# Before — agent gets a dead-end error
"Schema not found for kind: Device"

# After — agent can self-correct in the same turn
"Schema not found for kind: Device. Valid kinds: InfraDevice, InfraInterfaceL3, …
 Call get_schema() for the full catalog, or get_schema(kind='<kind>') for details."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `get_schema` tool for discovering available kinds, attributes, and filters in your schema

* **Improvements**
  * Enhanced error messages across query and write tools now provide remediation guidance, directing users to discover valid schema information first
  * Updated system prompts to emphasize schema discovery before querying or writing data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->