### PR TITLE
feat: pagination, session info tool, progress reporting (rebased onto feat/add-middleware)

### DIFF
--- a/src/infrahub_mcp/server.py
+++ b/src/infrahub_mcp/server.py
@@ -29,6 +29,7 @@ from infrahub_mcp.resources.schema import mcp as schema_resources_mcp
 from infrahub_mcp.tools.gql import mcp as graphql_mcp
 from infrahub_mcp.tools.nodes import mcp as nodes_mcp
 from infrahub_mcp.tools.schema import mcp as schema_tools_mcp
+from infrahub_mcp.tools.session import mcp as session_mcp
 from infrahub_mcp.tools.write import mcp as write_mcp
 from infrahub_mcp.utils import AppContext
 
@@ -227,6 +228,7 @@ mcp.mount(prompts_mcp)
 # Tools — read tools always available
 mcp.mount(graphql_mcp)
 mcp.mount(nodes_mcp)
+mcp.mount(session_mcp)
 mcp.mount(schema_tools_mcp)
 
 # Write tools — hidden in read-only mode

--- a/src/infrahub_mcp/tools/nodes.py
+++ b/src/infrahub_mcp/tools/nodes.py
@@ -41,6 +41,49 @@ _RESERVED_FILTER_KEYS: frozenset[str] = frozenset(
 )
 
 
+async def _fetch_nodes(  # noqa: PLR0913, PLR0917
+    client: "InfrahubClient",
+    schema: MainSchemaTypes,
+    branch: str | None,
+    filters: dict[str, Any] | None,
+    partial_match: bool,
+    include_attributes: bool,
+    limit: int | None,
+    offset: int | None,
+) -> list[Any]:
+    """Fetch nodes from Infrahub, delegating offset/limit directly to the SDK."""
+    kwargs: dict[str, Any] = {
+        "kind": schema.kind,
+        "branch": branch,
+        "offset": offset,
+        "limit": limit,
+        "parallel": True,
+        "order": Order(disable=True),
+        "populate_store": True,
+        "prefetch_relationships": include_attributes,
+    }
+    if filters:
+        return await client.filters(**kwargs, partial_match=partial_match, **filters)
+    return await client.all(**kwargs)
+
+
+async def _get_total_count(
+    client: "InfrahubClient",
+    kind: str,
+    branch: str | None,
+    partial_match: bool,
+    **filters: Any,
+) -> int:
+    """Return total count of matching nodes, or -1 if the count query fails.
+
+    Delegates directly to ``client.count()`` which accepts the same filter kwargs.
+    """
+    try:
+        return await client.count(kind=kind, branch=branch, partial_match=partial_match, **filters)
+    except GraphQLError:
+        return -1
+
+
 async def _validate_filters(  # noqa: PLR0913, PLR0917
     ctx: Context,
     client: "InfrahubClient",
@@ -134,8 +177,16 @@ async def get_nodes(  # pylint: disable=too-many-arguments,too-many-positional-a
             description="Maximum nodes to return. Default 50. Pass -1 for all results (caution: may be expensive).",
         ),
     ] = 50,
-) -> list[str] | str:
-    """Retrieve objects of a specific kind from Infrahub.
+    offset: Annotated[
+        int,
+        Field(
+            default=0,
+            ge=0,
+            description="Number of results to skip for pagination. Use with limit to page through results.",
+        ),
+    ] = 0,
+) -> dict[str, Any]:
+    """Retrieve objects of a specific kind from Infrahub with pagination support.
 
     To discover available kinds, read the ``infrahub://schema`` resource.
     If your client does not support MCP resources, call the ``get_schema`` tool instead.
@@ -148,6 +199,9 @@ async def get_nodes(  # pylint: disable=too-many-arguments,too-many-positional-a
     ``{"site__name__value": "atl1"}``). See ``infrahub://schema/{kind}`` for
     the full list of valid keys.
 
+    Use ``offset`` and ``limit`` to page through large result sets. The response
+    always includes ``total_count`` and ``has_more`` so you know when to stop.
+
     Args:
         kind: Kind of the objects to retrieve.
         branch: Branch to query. Defaults to the default branch.
@@ -155,9 +209,12 @@ async def get_nodes(  # pylint: disable=too-many-arguments,too-many-positional-a
         partial_match: Whether to use partial matching for string filters.
         include_attributes: Return full attribute dicts instead of display labels only.
         limit: Cap on results returned (default 50). Pass -1 for all.
+        offset: Number of results to skip (default 0). Use with limit to paginate.
 
     Returns:
-        A list of display labels (default) or a TOON-encoded string of full attribute dicts.
+        A dict with ``nodes`` (list of display labels or TOON-encoded string),
+        ``count`` (number of nodes in this page), ``total_count`` (total matching nodes),
+        ``has_more`` (whether more results exist), and ``offset`` / ``limit`` for context.
 
     Raises:
         RuntimeError: Via ``_log_and_raise_error`` when the schema is not found or the query fails.
@@ -166,7 +223,7 @@ async def get_nodes(  # pylint: disable=too-many-arguments,too-many-positional-a
     req_id = ctx.request_id
     await ctx.info(
         f"Fetching {kind} nodes: request_id={req_id!r}, branch={branch!r}, "
-        f"filter_keys={sorted(filters) if filters else []}, limit={limit}"
+        f"filter_keys={sorted(filters) if filters else []}, limit={limit}, offset={offset}"
     )
 
     try:
@@ -182,22 +239,17 @@ async def get_nodes(  # pylint: disable=too-many-arguments,too-many-positional-a
     if filters:
         await _validate_filters(ctx=ctx, client=client, schema=schema, kind=kind, branch=branch, filters=filters)
 
+    filter_kwargs = filters or {}
+    total_count = await _get_total_count(client, schema.kind, branch, partial_match, **filter_kwargs)
+
+    # Normalize limit: SDK uses None for "no limit", MCP tool uses -1
+    sdk_limit = None if limit == -1 else limit
+    sdk_offset = offset if offset > 0 else None
+
     try:
-        kwargs: dict[str, Any] = {
-            "kind": schema.kind,
-            "branch": branch,
-            "parallel": True,
-            "order": Order(disable=True),
-            "populate_store": True,
-            "prefetch_relationships": include_attributes,
-        }
-        if filters:
-            filter_kwargs: dict[str, Any] = {**kwargs, "partial_match": partial_match, **filters}
-            if limit > 0:
-                filter_kwargs["limit"] = limit
-            nodes = await client.filters(**filter_kwargs)
-        else:
-            nodes = await client.all(**kwargs)
+        nodes = await _fetch_nodes(
+            client, schema, branch, filters, partial_match, include_attributes, sdk_limit, sdk_offset
+        )
     except GraphQLError as exc:
         await _log_and_raise_error(
             ctx=ctx,
@@ -205,15 +257,27 @@ async def get_nodes(  # pylint: disable=too-many-arguments,too-many-positional-a
             remediation=f"Check the provided filters against infrahub://schema/{kind}.",
         )
 
-    capped = nodes if limit == -1 else nodes[:limit]
-    if include_attributes:
-        dicts = [await convert_node_to_dict(obj=node, branch=branch, include_id=True) for node in capped]
-        await ctx.debug(f"Retrieved {len(dicts)} nodes of kind {kind} with attributes (request_id={req_id!r})")
-        return toon.encode(dicts)
+    if total_count > 0:
+        await ctx.report_progress(progress=min(offset + len(nodes), total_count), total=total_count)
 
-    serialized = [obj.display_label for obj in capped]
-    await ctx.debug(f"Retrieved {len(serialized)} nodes of kind {kind} (request_id={req_id!r})")
-    return serialized
+    has_more = total_count > offset + len(nodes) if total_count >= 0 else len(nodes) == limit
+
+    if include_attributes:
+        dicts = [await convert_node_to_dict(obj=node, branch=branch, include_id=True) for node in nodes]
+        await ctx.debug(f"Retrieved {len(dicts)} nodes of kind {kind} with attributes (request_id={req_id!r})")
+        node_data: list[str] | str = toon.encode(dicts)
+    else:
+        node_data = [obj.display_label for obj in nodes]
+        await ctx.debug(f"Retrieved {len(node_data)} nodes of kind {kind} (request_id={req_id!r})")
+
+    return {
+        "nodes": node_data,
+        "count": len(nodes),
+        "total_count": total_count,
+        "has_more": has_more,
+        "offset": offset,
+        "limit": limit,
+    }
 
 
 @mcp.tool(tags={"nodes", "search"}, annotations=ToolAnnotations(readOnlyHint=True))

--- a/src/infrahub_mcp/tools/session.py
+++ b/src/infrahub_mcp/tools/session.py
@@ -1,0 +1,28 @@
+"""Session introspection tools for the Infrahub MCP server."""
+
+import os
+from typing import Any
+
+from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+
+mcp: FastMCP = FastMCP(name="Infrahub Session")
+
+
+@mcp.tool(tags={"session", "retrieve"}, annotations=ToolAnnotations(readOnlyHint=True))
+async def get_session_info(ctx: Context) -> dict[str, Any]:
+    """Return the current MCP session state.
+
+    Reports the active session branch (if any) and the Infrahub instance address.
+    Useful for multi-agent environments to understand connection state.
+
+    Returns:
+        Dict with ``session_branch`` (str or null), ``infrahub_address``, and ``has_session_branch``.
+    """
+    app_ctx = ctx.request_context.lifespan_context  # type: ignore[union-attr]
+    await ctx.debug("Returning session info")
+    return {
+        "session_branch": app_ctx.session_branch,
+        "has_session_branch": app_ctx.session_branch is not None,
+        "infrahub_address": os.environ.get("INFRAHUB_ADDRESS", "unknown"),
+    }

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -41,28 +41,53 @@ async def test_get_nodes() -> None:
     async with Client(mcp) as client:
         result = await client.call_tool("get_nodes", {"kind": "LocationSite"})
         assert result.is_error is False
-        assert isinstance(result.data, list)
-        assert sorted(result.data) == [
+        data = result.data  # type: ignore[attr-defined]
+        assert isinstance(data, dict)
+        assert sorted(data["nodes"]) == [
             "atl1",
             "den1",
             "dfw1",
             "jfk1",
             "ord1",
         ]
+        assert data["count"] == 5
+        assert "total_count" in data
+        assert "has_more" in data
+        assert "offset" in data
+        assert "limit" in data
 
 
 async def test_get_nodes_with_attributes() -> None:
     async with Client(mcp) as client:
         result = await client.call_tool("get_nodes", {"kind": "LocationSite", "include_attributes": True})
         assert result.is_error is False
-        # Data is TOON-encoded when include_attributes is True
-        assert isinstance(result.data, str)
-        decoded = toon.decode(result.data)
+        data = result.data  # type: ignore[attr-defined]
+        assert isinstance(data, dict)
+        decoded = toon.decode(data["nodes"])
         assert isinstance(decoded, list)
         assert len(decoded) > 0
         first = decoded[0]
         assert isinstance(first, dict)
         assert "name" in first
+
+
+async def test_get_nodes_pagination() -> None:
+    async with Client(mcp) as client:
+        # First page
+        result = await client.call_tool("get_nodes", {"kind": "LocationSite", "limit": 2, "offset": 0})
+        assert result.is_error is False
+        data = result.data  # type: ignore[attr-defined]
+        assert data["count"] == 2
+        assert data["offset"] == 0
+        assert data["limit"] == 2
+        assert len(data["nodes"]) == 2
+
+        # Second page
+        result2 = await client.call_tool("get_nodes", {"kind": "LocationSite", "limit": 2, "offset": 2})
+        assert result2.is_error is False
+        data2 = result2.data  # type: ignore[attr-defined]
+        assert data2["count"] == 2
+        assert data2["offset"] == 2
 
 
 async def test_search_nodes() -> None:
@@ -176,6 +201,18 @@ async def test_get_nodes_invalid_filter_includes_valid_filters() -> None:
         assert "Valid filters for LocationSite:" in text
         assert "name__value" in text
         assert "get_schema(kind='LocationSite')" in text
+
+
+async def test_get_session_info() -> None:
+    """get_session_info returns session state without errors."""
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_session_info", {})
+        assert result.is_error is False
+        data = result.data  # type: ignore[attr-defined]
+        assert "session_branch" in data
+        assert "has_session_branch" in data
+        assert "infrahub_address" in data
+        assert data["has_session_branch"] is False  # No writes yet, no session branch
 
 
 async def test_query_graphql_error_includes_schema_hint() -> None:


### PR DESCRIPTION
Rebases PR #61 onto the current `feat/add-middleware` (PR #62) so the pagination work can land alongside the middleware stack rather than waiting on the `stable` branch. The original PR targeted `stable`, which has since diverged significantly — this branch resolves the conflicts in `server.py` and `tools/nodes.py` (chiefly: the conditional `write_mcp` mount added by the middleware stack, and the `filters` docstring added in PR #78) while preserving the pagination envelope (`total_count`, `has_more`, `offset`, `limit`), the `get_session_info` tool, and `ctx.report_progress()` on long fetches.

```python
# get_nodes now returns a pagination envelope
{
    "nodes": [...],
    "count": 50,
    "total_count": 1284,
    "has_more": True,
    "offset": 0,
    "limit": 50,
}
```

This pairs naturally with the `StrictResponseLimitingMiddleware` from PR #78: agents now have a deterministic way to page instead of hitting a `ToolError` when responses exceed the 500 KB cap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add offset-based pagination to `get_nodes`, a `get_session_info` tool, and progress reporting for long fetches. This lets agents page safely under response size limits and understand session state.

- New Features
  - `get_nodes` now supports `offset`/`limit` and returns an envelope: `nodes`, `count`, `total_count`, `has_more`, `offset`, `limit`. Delegates to the SDK and reports progress. Works well with `StrictResponseLimitingMiddleware`.
  - Added `get_session_info` tool exposing `session_branch`, `has_session_branch`, and `infrahub_address`. Mounted in the server.

- Migration
  - `get_nodes` no longer returns a bare list/string. Read from the envelope: `data["nodes"]` (list of labels, or TOON-encoded string when `include_attributes` is true).
  - For large sets, page with `offset` and `limit`, and stop when `has_more` is false.

<sup>Written for commit 71bd2275b1a3ecc0b361337452cc1cfc9ecaa6a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

