### PR TITLE
Grant Release workflow id-token and packages permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  packages: write
 
 jobs:
   validate:


### PR DESCRIPTION
The Release workflow calls the reusable workflow-publish.yml via workflow_call. Reusable workflows cannot be granted more permissions than their caller. workflow-publish.yml requests id-token: write and packages: write, but the caller declared only contents: write, so GitHub blocked the call with:

  Error calling workflow ... is requesting 'packages: write,
  id-token: write', but is only allowed 'packages: none, id-token: none'

Add id-token: write and packages: write to release.yml so the permission grant flows through to the reusable workflow.