### PR TITLE
fix(cli): only pass host/port to mcp.run for streamable-http

### DIFF
--- a/src/infrahub_mcp/_cli.py
+++ b/src/infrahub_mcp/_cli.py
@@ -22,8 +22,11 @@ def main() -> None:
         msg = f"Auth mode {_config.auth_mode!r} requires streamable-http transport. Stdio has no HTTP headers."
         raise SystemExit(msg)
 
-    kwargs: dict[str, Any] = {"transport": args.transport, "host": args.host, "port": args.port}
-    asgi_mw = get_asgi_middleware()
-    if asgi_mw and args.transport == "streamable-http":
-        kwargs["middleware"] = asgi_mw
+    kwargs: dict[str, Any] = {"transport": args.transport}
+    if args.transport == "streamable-http":
+        kwargs["host"] = args.host
+        kwargs["port"] = args.port
+        asgi_mw = get_asgi_middleware()
+        if asgi_mw:
+            kwargs["middleware"] = asgi_mw
     mcp.run(**kwargs)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -41,9 +41,7 @@ class TestCliTransportKwargs:
             "port": 9000,
         }
 
-    def test_streamable_http_includes_middleware_when_available(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_streamable_http_includes_middleware_when_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: dict = {}
 
         def fake_run(**kwargs: object) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 
 from infrahub_mcp import _cli
@@ -34,12 +32,12 @@ class TestCliTransportKwargs:
     ) -> None:
         monkeypatch.setattr(
             "sys.argv",
-            ["infrahub-mcp", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000"],
+            ["infrahub-mcp", "--transport", "streamable-http", "--host", "192.0.2.10", "--port", "9000"],
         )
         _cli.main()
         assert captured_run_kwargs == {
             "transport": "streamable-http",
-            "host": "0.0.0.0",
+            "host": "192.0.2.10",
             "port": 9000,
         }
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,59 @@
+"""Tests for the infrahub-mcp CLI entry point."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from infrahub_mcp import _cli
+
+
+@pytest.fixture
+def captured_run_kwargs(monkeypatch: pytest.MonkeyPatch) -> dict:
+    captured: dict = {}
+
+    def fake_run(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(_cli.mcp, "run", fake_run)
+    monkeypatch.setattr(_cli, "get_asgi_middleware", lambda: None)
+    return captured
+
+
+class TestCliTransportKwargs:
+    def test_stdio_does_not_forward_host_or_port(
+        self, captured_run_kwargs: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("sys.argv", ["infrahub-mcp", "--transport", "stdio"])
+        _cli.main()
+        assert captured_run_kwargs == {"transport": "stdio"}
+
+    def test_streamable_http_forwards_host_and_port(
+        self, captured_run_kwargs: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "sys.argv",
+            ["infrahub-mcp", "--transport", "streamable-http", "--host", "0.0.0.0", "--port", "9000"],
+        )
+        _cli.main()
+        assert captured_run_kwargs == {
+            "transport": "streamable-http",
+            "host": "0.0.0.0",
+            "port": 9000,
+        }
+
+    def test_streamable_http_includes_middleware_when_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict = {}
+
+        def fake_run(**kwargs: object) -> None:
+            captured.update(kwargs)
+
+        sentinel = object()
+        monkeypatch.setattr(_cli.mcp, "run", fake_run)
+        monkeypatch.setattr(_cli, "get_asgi_middleware", lambda: sentinel)
+        monkeypatch.setattr("sys.argv", ["infrahub-mcp", "--transport", "streamable-http"])
+        _cli.main()
+        assert captured["middleware"] is sentinel


### PR DESCRIPTION
## Summary
- Fixes #89 — `infrahub-mcp --transport stdio` crashed with `TypeError: TransportMixin.run_stdio_async() got an unexpected keyword argument 'host'` because `_cli.py` forwarded `--host`/`--port` to `mcp.run()` for every transport. Stdio is what Claude Code and most MCP clients use, so the CLI entrypoint was effectively broken for them.
- Build the `mcp.run()` kwargs conditionally: stdio gets only `transport`; `streamable-http` keeps host/port plus the ASGI middleware.
- Add `tests/unit/test_cli.py` covering both transports and the middleware path.

## Test plan
- [x] `uv run pytest tests/unit/test_cli.py` — 3 new tests pass
- [x] `uv run pytest tests/unit` — 328 passed, 18 skipped (no regressions)
- [ ] Manual: `uvx --from <this-branch> infrahub-mcp --transport stdio` should accept an MCP `initialize` request instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `infrahub-mcp` CLI crash on `stdio` by only passing host/port to `mcp.run()` when transport is `streamable-http`. Fixes #89.

- **Bug Fixes**
  - Build kwargs conditionally and only attach ASGI middleware in `streamable-http`.
  - Add unit tests for both transports and the middleware path; clean up tests for ruff (use `192.0.2.10`, remove unused import, collapse test signature).

<sup>Written for commit f18631fde52cdec9c277498d18258c6b73cec917. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

