### PR TITLE
fix(ci): restore version-drafter.yml deleted in #94

### DIFF
--- a/.github/version-drafter.yml
+++ b/.github/version-drafter.yml
@@ -1,0 +1,21 @@
+---
+# Label-to-semver mapping for patrickjahns/version-drafter-action.
+# REQUIRED FILE — action crashes with "Invalid config file" if absent.
+# Both type/* and changes/* labels drive version bumps.
+# changes/* labels serve as explicit overrides when the type label
+# doesn't reflect the desired bump level.
+
+version_major_labels:
+  - "changes/major"
+  - "type/breaking-change"
+
+version_minor_labels:
+  - "changes/minor"
+  - "type/feature"
+  - "type/refactoring"
+
+version_patch_labels:
+  - "changes/patch"
+  - "type/bug"
+  - "type/housekeeping"
+  - "type/documentation"


### PR DESCRIPTION
## Summary

PR #94 deleted \`.github/version-drafter.yml\` on the (incorrect) assumption that the action would default to patch when the file is absent. It doesn't — \`patrickjahns/version-drafter-action@v1.3.1\` hard-requires the file and crashes with \`Invalid config file: Not Found\` when missing, causing auto-bump to fail on the merge commit of #94.

Restore the file with its original label→semver mapping.

## Test plan

- [ ] CI green
- [ ] On merge to stable, auto-bump succeeds and tags \`v1.1.3\`
- [ ] Release-drafter draft includes #85, #86, #90, #91, #94 and this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `.github/version-drafter.yml` to fix CI auto-bump failures introduced by #94. `patrickjahns/version-drafter-action@v1.3.1` requires this file and crashed when it was missing.

- **Bug Fixes**
  - Re-added the version-drafter config with the original label→semver mapping so bumps are computed from `type/*` and `changes/*` labels and release drafts run on merges to `stable`.

<sup>Written for commit bc676ad16270cd7b5b029d478c1868d01a44f66f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

