### PR TITLE
fix(session): validate cached session branch before reuse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
     "mypy>=1.17.0",
     "pytest>=8.4.1",
     "pytest-asyncio>=1.1.0",
-    "ruff>=0.15.5",
+    "ruff>=0.15.11",
     "pylint>=4.0.5",
     "yamllint>=1.37.1",
 ]

--- a/src/infrahub_mcp/server.py
+++ b/src/infrahub_mcp/server.py
@@ -70,7 +70,7 @@ def _validate_env() -> None:
 
 
 @asynccontextmanager
-async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:  # noqa: ARG001, RUF029
+async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:  # noqa: ARG001
     """Manage the application lifecycle: validate config, create client, yield context."""
     _validate_env()
     client = (

--- a/src/infrahub_mcp/utils.py
+++ b/src/infrahub_mcp/utils.py
@@ -10,8 +10,8 @@ from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from infrahub_sdk import Config
 from infrahub_sdk.client import InfrahubClient
+from infrahub_sdk.exceptions import BranchNotFoundError, GraphQLError, NodeNotFoundError
 from infrahub_sdk.exceptions import Error as SdkError
-from infrahub_sdk.exceptions import GraphQLError, NodeNotFoundError
 from infrahub_sdk.node import Attribute, InfrahubNode, RelatedNode, RelationshipManager
 
 from infrahub_mcp.auth import get_passthrough_basic, get_passthrough_token, get_user_from_token
@@ -197,14 +197,27 @@ async def get_or_create_session_branch(ctx: Context) -> str:
     - Fixed names (no placeholders) attempt a single creation — if the branch
       already exists the server raises a clear error.
 
-    Branch creation is attempted directly to avoid TOCTOU races between
-    checking existence and creating.
+    The cached branch name is validated against Infrahub before reuse — if it
+    has been deleted (merged proposed change, manual delete, dev server reset)
+    the cache is cleared and a new branch is created. Without this check the
+    cache is process-scoped and a stale name would persist across MCP sessions
+    until the server process restarts.
     """
     if ctx.request_context is None:
         msg = "request_context must not be None"
         raise RuntimeError(msg)
     app_ctx: AppContext = ctx.request_context.lifespan_context
     async with app_ctx._session_branch_lock:  # noqa: SLF001
+        if app_ctx.session_branch is not None:
+            client = get_client(ctx)
+            try:
+                await client.branch.get(branch_name=app_ctx.session_branch)
+            except BranchNotFoundError:
+                await ctx.warning(
+                    f"Cached session branch {app_ctx.session_branch!r} no longer exists on "
+                    "Infrahub; creating a new one."
+                )
+                app_ctx.session_branch = None
         if app_ctx.session_branch is None:
             if _has_placeholders(app_ctx.config.branch_pattern):
                 app_ctx.session_branch = await _create_branch_with_pattern(app_ctx, ctx)

--- a/tests/unit/test_session_branch_validation.py
+++ b/tests/unit/test_session_branch_validation.py
@@ -1,0 +1,83 @@
+"""Tests for session branch validation against stale cache.
+
+Regression coverage for the bug where ``AppContext.session_branch`` is cached
+for the lifetime of the MCP server process, but the underlying branch may
+have been deleted on Infrahub (merged proposed change, manual delete, dev
+server reset). Writes then 404 against the stale branch name until the
+server process restarts.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from infrahub_sdk.exceptions import BranchNotFoundError
+
+from infrahub_mcp.config import ServerConfig
+from infrahub_mcp.utils import AppContext, get_or_create_session_branch
+
+
+def _make_ctx(app_ctx: AppContext) -> MagicMock:
+    """Create a mock FastMCP Context with the given AppContext."""
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = app_ctx
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    ctx.debug = AsyncMock()
+    return ctx
+
+
+class TestGetOrCreateSessionBranch:
+    async def test_returns_cached_branch_when_it_still_exists(self) -> None:
+        """Cached branch is reused when it still exists on Infrahub — no re-create."""
+        config = ServerConfig(auth_mode="none")
+        app_ctx = AppContext(client=MagicMock(), config=config, session_branch="mcp/session-existing")
+
+        client = MagicMock()
+        client.branch.get = AsyncMock(return_value=MagicMock())
+        client.branch.create = AsyncMock()
+
+        ctx = _make_ctx(app_ctx)
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            result = await get_or_create_session_branch(ctx)
+
+        assert result == "mcp/session-existing"
+        assert app_ctx.session_branch == "mcp/session-existing"
+        client.branch.create.assert_not_called()
+        client.branch.get.assert_called_once_with(branch_name="mcp/session-existing")
+
+    async def test_recreates_when_cached_branch_was_deleted(self) -> None:
+        """Stale cached branch (deleted on server) triggers creation of a new one."""
+        config = ServerConfig(auth_mode="none", branch_pattern="mcp/session-{date}-{hex}")
+        app_ctx = AppContext(client=MagicMock(), config=config, session_branch="mcp/session-stale")
+
+        client = MagicMock()
+        client.branch.get = AsyncMock(side_effect=BranchNotFoundError(identifier="mcp/session-stale"))
+        client.branch.create = AsyncMock()
+
+        ctx = _make_ctx(app_ctx)
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            result = await get_or_create_session_branch(ctx)
+
+        assert result != "mcp/session-stale"
+        assert result.startswith("mcp/session-")
+        assert app_ctx.session_branch == result
+        client.branch.create.assert_called_once()
+
+    async def test_creates_when_no_cached_branch(self) -> None:
+        """First write of a process creates a new branch — no validation lookup."""
+        config = ServerConfig(auth_mode="none", branch_pattern="mcp/session-{date}-{hex}")
+        app_ctx = AppContext(client=MagicMock(), config=config, session_branch=None)
+
+        client = MagicMock()
+        client.branch.get = AsyncMock()
+        client.branch.create = AsyncMock()
+
+        ctx = _make_ctx(app_ctx)
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            result = await get_or_create_session_branch(ctx)
+
+        assert result.startswith("mcp/session-")
+        assert app_ctx.session_branch == result
+        client.branch.create.assert_called_once()
+        client.branch.get.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -584,7 +584,7 @@ dev = [
     { name = "pylint", specifier = ">=4.0.5" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
-    { name = "ruff", specifier = ">=0.15.5" },
+    { name = "ruff", specifier = ">=0.15.11" },
     { name = "rumdl", specifier = ">=0.1.68" },
     { name = "ty", specifier = ">=0.0.32" },
     { name = "yamllint", specifier = ">=1.37.1" },


### PR DESCRIPTION
## Summary

- The session branch is cached on the process-wide `AppContext`, so once set it persists across every MCP session for the lifetime of the server process. If the underlying branch was deleted on Infrahub (merged proposed change, manual delete, dev server reset) the cache went stale and every subsequent write 404'd against the missing branch — agents saw `has_session_branch: true` while writes failed with "branch not found" until the server was restarted.
- `get_or_create_session_branch` now validates the cached name via `client.branch.get()` before reuse. On `BranchNotFoundError` it clears the cache, emits a warning, and falls through to the existing creation path so the next write proceeds on a fresh branch.
- Adds 3 unit tests covering: cached-branch reuse (one validation lookup, no recreate), stale-cache recreation (the bug), and first-write creation path (no lookup).

## Background

ADR-0005 describes the branch as cached "for the session", but the implementation caches on the lifespan-scoped `AppContext` — which FastMCP keeps alive for the lifetime of the server process (`fastmcp/server/mixins/lifespan.py`). So "new chat" / "new task" in Claude Desktop does **not** reset the cached branch; only restarting the MCP server does. This change is the minimal safety net; a follow-up should move session state to be per-MCP-session (closes the multi-user leak in passthrough auth modes too).

## Test plan

- [x] `uv run pytest` — 331 passed, 18 skipped (live-Infrahub integration tests).
- [x] `uv run invoke lint-ruff lint-yaml lint-pylint` — all clean (pylint 10.00/10).
- [x] Mypy: no new errors; 5 pre-existing errors in `convert_node_to_dict` are unrelated.
- [x] Tests written test-first and verified failing before the fix landed.
- [ ] Manual: with an existing session branch deleted on Infrahub, confirm the next `node_upsert` / `mutate_graphql` triggers warning log + creates a fresh branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates the cached session branch before reuse to prevent 404s when the branch was deleted on Infrahub. If missing, the cache is cleared, a warning is logged, and a new branch is created so writes proceed without restarting the server.

- **Bug Fixes**
  - `get_or_create_session_branch` calls `client.branch.get()` for the cached name; on `BranchNotFoundError`, clears `AppContext.session_branch` and creates a new one.
  - Avoids stale, process-wide cache in `fastmcp` sessions that caused failed writes.
  - Adds unit tests for: valid cache reuse, stale-cache recreation, and first-write creation.

- **Dependencies**
  - Bumps dev `ruff` to `>=0.15.11` to honor the `@asynccontextmanager` RUF029 exception and keep lint passing; drops the unused RUF029 suppression in `app_lifespan`.

<sup>Written for commit 8b9cebcbbb1d2e48cbba4e34616f90150f0776e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-mcp/pull/110?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

