### PR TITLE
fix(session): scope session branch to MCP session, not server process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
     "mypy>=1.17.0",
     "pytest>=8.4.1",
     "pytest-asyncio>=1.1.0",
-    "ruff>=0.15.5",
+    "ruff>=0.15.11",
     "pylint>=4.0.5",
     "yamllint>=1.37.1",
 ]

--- a/src/infrahub_mcp/server.py
+++ b/src/infrahub_mcp/server.py
@@ -70,7 +70,7 @@ def _validate_env() -> None:
 
 
 @asynccontextmanager
-async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:  # noqa: ARG001, RUF029
+async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:  # noqa: ARG001
     """Manage the application lifecycle: validate config, create client, yield context."""
     _validate_env()
     client = (

--- a/src/infrahub_mcp/tools/session.py
+++ b/src/infrahub_mcp/tools/session.py
@@ -6,6 +6,8 @@ from typing import Any
 from fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 
+from infrahub_mcp.utils import SESSION_BRANCH_STATE_KEY
+
 mcp: FastMCP = FastMCP(name="Infrahub Session")
 
 
@@ -28,13 +30,10 @@ async def get_session_info(ctx: Context) -> dict[str, Any]:
     Returns:
         Dict with ``session_branch`` (str or null), ``infrahub_address``, and ``has_session_branch``.
     """
-    if ctx.request_context is None:
-        msg = "request_context must not be None"
-        raise RuntimeError(msg)
-    app_ctx = ctx.request_context.lifespan_context
+    session_branch = await ctx.get_state(SESSION_BRANCH_STATE_KEY)
     await ctx.debug("Returning session info")
     return {
-        "session_branch": app_ctx.session_branch,
-        "has_session_branch": app_ctx.session_branch is not None,
+        "session_branch": session_branch,
+        "has_session_branch": session_branch is not None,
         "infrahub_address": os.environ.get("INFRAHUB_ADDRESS", "unknown"),
     }

--- a/src/infrahub_mcp/tools/write.py
+++ b/src/infrahub_mcp/tools/write.py
@@ -11,6 +11,7 @@ from pydantic import Field
 from infrahub_mcp.auth import assert_writable_branch
 from infrahub_mcp.schema import get_valid_kinds_summary
 from infrahub_mcp.utils import (
+    SESSION_BRANCH_STATE_KEY,
     _log_and_raise_error,
     get_client,
     get_default_branch,
@@ -267,19 +268,13 @@ async def propose_changes(
         Dict with proposed change id and branch details on success.
     """
     client = get_client(ctx)
-    if ctx.request_context is None:
-        msg = "request_context must not be None"
-        raise RuntimeError(msg)
-    app_ctx = ctx.request_context.lifespan_context
-
-    if app_ctx.session_branch is None:
+    session_branch = await ctx.get_state(SESSION_BRANCH_STATE_KEY)
+    if session_branch is None:
         await _log_and_raise_error(
             ctx=ctx,
             error="No session branch exists yet.",
             remediation="Make at least one write (node_upsert / node_delete) before proposing changes.",
         )
-
-    session_branch: str = app_ctx.session_branch
 
     if destination_branch is None:
         branches = await client.branch.all()

--- a/src/infrahub_mcp/utils.py
+++ b/src/infrahub_mcp/utils.py
@@ -20,14 +20,24 @@ from infrahub_mcp.constants import AUTH_MODE_BASIC_PASSTHROUGH, AUTH_MODE_TOKEN_
 
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
 
+SESSION_BRANCH_STATE_KEY = "session_branch"
+
 
 @dataclass
 class AppContext:
-    """Application context held for the lifetime of an MCP connection."""
+    """Application context held for the lifetime of the MCP server process.
+
+    Holds only state that is genuinely process-scoped (the shared SDK client,
+    server configuration, and the cached default-branch name — a property of
+    the Infrahub instance, not of any caller). Per-MCP-session state — most
+    importantly the session branch name — lives in FastMCP's per-session
+    state store, keyed by ``Context.session_id``, so independent MCP sessions
+    served by the same process never share branches or leak across users in
+    passthrough auth modes.
+    """
 
     client: InfrahubClient | None
     config: ServerConfig
-    session_branch: str | None = field(default=None)
     default_branch: str | None = field(default=None)
     _session_branch_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _default_branch_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -189,28 +199,34 @@ async def get_default_branch(ctx: Context) -> str:
 
 
 async def get_or_create_session_branch(ctx: Context) -> str:
-    """Return the session branch, auto-creating it on the first write of the session.
+    """Return the per-MCP-session branch, auto-creating it on the first write.
+
+    The branch name is cached in FastMCP's per-session state store
+    (``ctx.set_state`` / ``ctx.get_state``), keyed by the MCP session id —
+    so two independent MCP sessions served by the same server process get
+    independent branches, and the cache disappears when the session ends
+    (or its TTL expires).
 
     Uses the branch pattern from ``ServerConfig.branch_pattern``:
     - Patterns with placeholders ({date}, {hex}, {user}) are expanded.
       If creation fails due to a name conflict, a new {hex} is generated (up to max retries).
     - Fixed names (no placeholders) attempt a single creation — if the branch
       already exists the server raises a clear error.
-
-    Branch creation is attempted directly to avoid TOCTOU races between
-    checking existence and creating.
     """
     if ctx.request_context is None:
         msg = "request_context must not be None"
         raise RuntimeError(msg)
     app_ctx: AppContext = ctx.request_context.lifespan_context
     async with app_ctx._session_branch_lock:  # noqa: SLF001
-        if app_ctx.session_branch is None:
-            if _has_placeholders(app_ctx.config.branch_pattern):
-                app_ctx.session_branch = await _create_branch_with_pattern(app_ctx, ctx)
-            else:
-                app_ctx.session_branch = await _create_branch_fixed(app_ctx, ctx)
-    return app_ctx.session_branch
+        cached = await ctx.get_state(SESSION_BRANCH_STATE_KEY)
+        if cached is not None:
+            return str(cached)
+        if _has_placeholders(app_ctx.config.branch_pattern):
+            branch_name = await _create_branch_with_pattern(app_ctx, ctx)
+        else:
+            branch_name = await _create_branch_fixed(app_ctx, ctx)
+        await ctx.set_state(SESSION_BRANCH_STATE_KEY, branch_name)
+        return branch_name
 
 
 async def _log_and_raise_error(ctx: Context, error: str | Exception, remediation: str | None = None) -> NoReturn:

--- a/tests/unit/test_session_isolation.py
+++ b/tests/unit/test_session_isolation.py
@@ -1,0 +1,101 @@
+"""Tests for per-MCP-session isolation of the session branch.
+
+Regression coverage for the bug where ``session_branch`` was cached on the
+process-wide ``AppContext``, causing every MCP session served by the same
+server process to reuse the same branch — both stale-cache symptoms (the
+underlying branch may have been deleted) and a credential leak in
+passthrough auth modes (User A's branch becomes User B's).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from infrahub_mcp.config import ServerConfig
+from infrahub_mcp.utils import AppContext, get_or_create_session_branch
+
+
+class _SessionState:
+    """In-memory stand-in for FastMCP's per-session state store."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+
+    async def get_state(self, key: str) -> Any:
+        return self._data.get(key)
+
+    async def set_state(self, key: str, value: Any, **_: Any) -> None:
+        self._data[key] = value
+
+
+def _make_ctx(app_ctx: AppContext, client: MagicMock) -> MagicMock:
+    """Create a mock FastMCP Context with isolated per-session state."""
+    state = _SessionState()
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = app_ctx
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    ctx.debug = AsyncMock()
+    ctx.get_state = state.get_state
+    ctx.set_state = state.set_state
+    # get_client(ctx) returns this client — patch into utils via monkeypatch
+    ctx._test_client = client  # noqa: SLF001
+    return ctx
+
+
+class TestSessionBranchIsolation:
+    async def test_two_sessions_get_independent_branches(self, monkeypatch: Any) -> None:
+        """Two MCP sessions sharing one server process must not share a branch."""
+        config = ServerConfig(auth_mode="none", branch_pattern="mcp/session-{hex}")
+        app_ctx = AppContext(client=MagicMock(), config=config)
+
+        client_a = MagicMock()
+        client_a.branch.create = AsyncMock()
+        client_b = MagicMock()
+        client_b.branch.create = AsyncMock()
+
+        ctx_a = _make_ctx(app_ctx, client_a)
+        ctx_b = _make_ctx(app_ctx, client_b)
+
+        def fake_get_client(ctx: Any) -> Any:
+            return ctx._test_client  # noqa: SLF001
+
+        monkeypatch.setattr("infrahub_mcp.utils.get_client", fake_get_client)
+
+        branch_a = await get_or_create_session_branch(ctx_a)
+        branch_b = await get_or_create_session_branch(ctx_b)
+
+        assert branch_a != branch_b
+        assert branch_a.startswith("mcp/session-")
+        assert branch_b.startswith("mcp/session-")
+        client_a.branch.create.assert_called_once()
+        client_b.branch.create.assert_called_once()
+
+    async def test_same_session_reuses_cached_branch(self, monkeypatch: Any) -> None:
+        """Two writes within the same MCP session reuse the same branch."""
+        config = ServerConfig(auth_mode="none", branch_pattern="mcp/session-{hex}")
+        app_ctx = AppContext(client=MagicMock(), config=config)
+
+        client = MagicMock()
+        client.branch.create = AsyncMock()
+        ctx = _make_ctx(app_ctx, client)
+
+        def fake_get_client(_: Any) -> Any:
+            return client
+
+        monkeypatch.setattr("infrahub_mcp.utils.get_client", fake_get_client)
+
+        first = await get_or_create_session_branch(ctx)
+        second = await get_or_create_session_branch(ctx)
+
+        assert first == second
+        client.branch.create.assert_called_once()
+
+    async def test_session_branch_not_stored_on_appcontext(self) -> None:
+        """``AppContext`` must not expose a process-wide ``session_branch`` field."""
+        # The architectural fix removes the field entirely. Test fails until the
+        # field is gone, which is exactly the regression we want to prevent.
+        config = ServerConfig(auth_mode="none")
+        app_ctx = AppContext(client=MagicMock(), config=config)
+        assert not hasattr(app_ctx, "session_branch")

--- a/uv.lock
+++ b/uv.lock
@@ -584,7 +584,7 @@ dev = [
     { name = "pylint", specifier = ">=4.0.5" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
-    { name = "ruff", specifier = ">=0.15.5" },
+    { name = "ruff", specifier = ">=0.15.11" },
     { name = "rumdl", specifier = ">=0.1.68" },
     { name = "ty", specifier = ">=0.0.32" },
     { name = "yamllint", specifier = ">=1.37.1" },


### PR DESCRIPTION
## Summary

Architectural fix for the same root cause as #110. The session branch was cached on `AppContext`, which FastMCP keeps alive for the **lifetime of the server process** — not per MCP session. Two consequences:

1. **Stale cache across sessions** (the symptom #110 patches with a validation lookup): once any session created a branch, every later session reused the cached name. If the underlying branch was deleted on Infrahub (merged PC, manual delete, dev reset), all subsequent writes 404'd until the server restarted.
2. **Credential leak in passthrough auth**: in `token`/`basic` passthrough modes the same shared `session_branch` is used by every authenticated caller. User A creates a branch, User B's write then targets it — audit trail wrong, branch isolation broken.

This PR moves `session_branch` off `AppContext` into FastMCP's per-session state store (`Context.set_state` / `get_state`, key auto-prefixed by `Context.session_id`). The cache lives exactly as long as the MCP session and disappears with it. `AppContext` retains only state that is genuinely process-scoped (shared SDK client, server config, cached default-branch name — a property of the Infrahub instance, not of any caller).

## Relationship to #110

- #110 is a tactical fix: validate the cached name on each first-write to recover from "branch deleted" mid-session. Small, low-risk, immediate user relief.
- This PR is the architectural fix that **subsumes** the cross-session symptom #110 patches around AND fixes the credential leak that #110 cannot.

Recommended sequence: land #110 first (already reviewed, ready), then this. When this lands, the validation lookup from #110 remains useful as defense-in-depth for "branch deleted mid-session" (e.g. a human deletes it via the UI). Trivial merge conflict in `utils.py` and `uv.lock` either way.

## Changes

- `src/infrahub_mcp/utils.py`: drop `session_branch` field from `AppContext`; introduce `SESSION_BRANCH_STATE_KEY` constant; `get_or_create_session_branch` reads/writes via `ctx.get_state` / `ctx.set_state`.
- `src/infrahub_mcp/tools/session.py`: `get_session_info` reads per-session state.
- `src/infrahub_mcp/tools/write.py`: `propose_changes` reads per-session state.
- `pyproject.toml` / `uv.lock`: bump `ruff>=0.15.11` (same rationale as the second commit on #110 — the `@asynccontextmanager` exception for `RUF029` lives in 0.15.11; `invoke format` strips the now-unused suppression on `app_lifespan` and we don't want lint to fail for anyone on 0.15.5–0.15.10).

## Test plan

- [x] `uv run pytest` — 331 passed, 18 skipped (live-Infrahub integration tests).
- [x] `uv run invoke lint-ruff lint-yaml lint-pylint` — all clean (pylint 10.00/10).
- [x] Mypy: no new errors; same 5 pre-existing errors in `convert_node_to_dict`.
- [x] New `tests/unit/test_session_isolation.py` (TDD — verified failing first):
  - two MCP sessions sharing one server process get independent branches
  - same session reuses the cached branch across multiple writes
  - `AppContext` no longer exposes a process-wide `session_branch` field (regression guard)
- [ ] Manual: open two MCP clients against the same server, perform a write in each, confirm two distinct session branches on Infrahub.

## Notes

- `_session_branch_lock` stays on `AppContext` to serialize the check-then-create on first write. It is process-wide, but contention is brief (only during branch creation, which is rare).
- FastMCP's default in-memory state store applies a 24-hour TTL. For session branches this is fine — a session idle for >24h gets a fresh branch on the next write, which is the correct behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope the session branch to each MCP session instead of the server process to stop cross-session reuse and fix a credential leak in passthrough auth. The branch name now lives in FastMCP per-session state and is cleared with the session.

- **Bug Fixes**
  - Store `session_branch` in per-session state via `Context.get_state`/`set_state` under `SESSION_BRANCH_STATE_KEY`; remove it from `AppContext`.
  - Update `get_session_info` and `propose_changes` to read per-session state; keep a process-wide lock only for first-time branch creation.
  - Add unit tests for session isolation and same-session cache reuse.

- **Dependencies**
  - Bump `ruff` to `>=0.15.11` to support the `@asynccontextmanager` exception and keep lint passing.

<sup>Written for commit 729148967aa15661cac75cde3c17bd63c84b6d5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-mcp/pull/111?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

