### PR TITLE
feat(session): recover stale session branch, add reset tool, harden writes

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,9 +1,9 @@
 ## Infrahub MCP Server 1.1.5
 
-| ✔ Tools (9) | ✔ Prompts (4) | ✔ Resources (3) | ✔ Logging | ~~<span style="opacity:0.6" class="error">✘ Completions</span>~~ | ~~<span style="opacity:0.6" class="error">✘ Tasks</span>~~ |
+| ✔ Tools (10) | ✔ Prompts (4) | ✔ Resources (3) | ✔ Logging | ~~<span style="opacity:0.6" class="error">✘ Completions</span>~~ | ~~<span style="opacity:0.6" class="error">✘ Tasks</span>~~ |
 | --- | --- | --- | --- | --- | --- |
 
-## 🛠️ Tools (9)
+## 🛠️ Tools (10)
 
 <table style="text-align: left;">
 <thead>
@@ -75,10 +75,9 @@
             <td>
                 <code><b>mutate_graphql</b></code>
             </td>
-            <td>Execute a GraphQL mutation against Infrahub — use only for complex writes that typed tools can't express.<br/><br/>Prefer `<code>node_upsert</code>` (create/update scalar attributes) or `<code>node_delete</code>`<br/>(remove a node) for straightforward changes; they validate against the<br/>schema and produce clearer audit entries. Reach for `<code>mutate_graphql</code>`<br/>when you need relationship edits, bulk operations, or any mutation shape<br/>not covered by the typed tools. For reads, use `<code>query_graphql</code>`.<br/><br/>The mutation targets the session branch by default, which is auto-created<br/>on the first write of the session (``mcp/session-YYYYMMDD-<hex>``).<br/><br/>To discover available kinds and their attributes, read the ``infrahub://schema``<br/>resource or call the `<code>get_schema</code>` tool.<br/>For the full GraphQL SDL, read ``infrahub://graphql-schema``.</td>
+            <td>Execute a GraphQL mutation against Infrahub — use only for complex writes that typed tools can't express.<br/><br/>Prefer `<code>node_upsert</code>` (create/update scalar attributes) or `<code>node_delete</code>`<br/>(remove a node) for straightforward changes; they validate against the<br/>schema and produce clearer audit entries. Reach for `<code>mutate_graphql</code>`<br/>when you need relationship edits, bulk operations, or any mutation shape<br/>not covered by the typed tools. For reads, use `<code>query_graphql</code>`.<br/><br/>The mutation always runs on the **active session branch** (auto-created on the<br/>first write of the session, ``mcp/session-YYYYMMDD-<hex>``). There is no branch<br/>override — writes are isolated to the session, and changes reach the default<br/>branch only through `<code>propose_changes</code>` and human review. To target a different<br/>branch deliberately, switch the session with `<code>reset_session_branch</code>` first.<br/>Branch- and schema-management mutations are rejected.<br/><br/>To discover available kinds and their attributes, read the ``infrahub://schema``<br/>resource or call the `<code>get_schema</code>` tool.<br/>For the full GraphQL SDL, read ``infrahub://graphql-schema``.</td>
             <td>
                 <ul>
-                    <li> <code>branch</code> : string | null<br /></li>
                     <li> <code>query</code> : string<br /></li>
                 </ul>
             </td>
@@ -153,6 +152,21 @@
         </tr>
         <tr>
             <td>9.</td>
+            <td>
+                <!--- no icon -->
+            </td>
+            <td>
+                <code><b>reset_session_branch</b></code>
+            </td>
+            <td>Reset or switch the active session branch for the current MCP session.<br/><br/>Use this to recover or take control of which branch your writes target:<br/><br/>- **No `<code>branch</code>`** — clears the cached session branch; the next write<br/>  auto-creates a fresh one. Useful after you have merged your work and want<br/>  to start a new change set.<br/>- **With `<code>branch</code>`** — points this session at the named branch. If it does<br/>  not exist and the name matches the configured branch pattern, it is created<br/>  and reported. The instance default branch and merged/read-only branches are<br/>  rejected.<br/><br/>Note: a merged or deleted session branch is recovered **automatically** on the<br/>next write — this tool is the explicit override on top of that.<br/><br/>Affects only the calling session; other sessions are unaffected.</td>
+            <td>
+                <ul>
+                    <li> <code>branch</code> : string | null<br /></li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td>10.</td>
             <td>
                 <!--- no icon -->
             </td>

--- a/dev/adr/0007-per-session-branch-recovery-and-reset.md
+++ b/dev/adr/0007-per-session-branch-recovery-and-reset.md
@@ -1,0 +1,64 @@
+# 7. Per-Session Branch Recovery, Reset, and Scoping
+
+**Status:** Accepted
+**Date:** 2026-06-04
+**Author:** @bkohler
+
+## Context
+
+[ADR 0005](0005-lazy-session-branch-creation.md) introduced a lazily-created session branch cached on `AppContext`. Two gaps surfaced in production:
+
+1. The cache was only invalidated when the branch was **deleted** (`BranchNotFoundError`). But merging a branch in Infrahub does **not** delete it — it stays present and becomes **read-only** (`BranchStatus.MERGED`). After an operator merged the session branch (the normal end-of-work step), every subsequent write was routed to a read-only branch and failed (`"Branch ... has been merged and is read-only"`), wedging the write path until the server restarted.
+2. `AppContext` is shared across MCP sessions for the process lifetime, so a single cached `session_branch` was effectively process-global: one session's branch (and any reset/recovery) affected all sessions. There was also no way to reset or switch the branch within a session.
+
+## Decision
+
+- **Per-session scoping.** Replace the `session_branch` scalar with `WeakKeyDictionary` maps on `AppContext` keyed by the per-session object (`ctx.request_context.session`, via `_session_obj()`): one for the active branch name, one for a per-session `asyncio.Lock` (created lazily under a guard lock). Weak keys release entries automatically when a session ends — no unbounded growth — and isolate sessions from each other.
+- **Proactive recovery.** `get_or_create_session_branch()` validates the cached branch with the existing single `client.branch.get()` and now also inspects `BranchData.status`. A status in `{MERGED, DELETING}` (read-only / being removed) is treated like a missing branch: the entry is cleared and a fresh branch is provisioned, warning the caller with **both** the old and new branch names. Writable statuses (`OPEN`, `NEED_REBASE`, `NEED_UPGRADE_REBASE`) are reused.
+- **Reactive recovery (TOCTOU).** A branch can be merged between validation and the write. The write tools (`node_upsert`, `node_delete`, `mutate_graphql`) catch a read-only/merged-looking `GraphQLError` and then **confirm via `client.branch.get()` status that the branch is actually merged/deleted before clearing it** — the error text alone is ambiguous (a read-only *attribute* error reads the same), and clearing on a false positive would orphan the user's work on a still-writable branch. Only when confirmed stale do they clear the session entry (under the per-session lock) and raise a retryable error. The failed mutation is **not** replayed (an arbitrary mutation could partially apply).
+- **Explicit reset/override.** A new write-tagged tool `reset_session_branch(branch=None)`: with no argument it clears the session's branch (next write provisions a fresh one); with a name it switches the session to that branch — created when the name conforms to the configured `branch_pattern` (`branch_name_conforms()`), and rejected for the default branch or a merged/read-only branch.
+
+### Write-authorization hardening
+
+A review of the write path surfaced ways an agent could write outside its session branch or reach the default branch, bypassing the `propose_changes` review gate. Hardened as follows:
+
+- **Writes pinned to the session branch.** `mutate_graphql` no longer accepts a per-call `branch` override — like `node_upsert`/`node_delete`, it always targets the active session branch. Changing which branch a session uses is only possible deliberately via `reset_session_branch` (still default-blocked). This removes the ability to transiently aim a write at an arbitrary (e.g. another session's) feature branch.
+- **Privileged mutations blocked.** `mutate_graphql` now parses the query AST and rejects non-mutation operations and — scanning field names **recursively through inline fragments and fragment definitions** so they can't be smuggled in via `... on Mutation { ... }` — Infrahub branch-management mutations (`BranchCreate/Delete/Merge/Rebase/Update/Validate`) and schema mutations (`SchemaDropdown*`, `SchemaEnum*`). These operate independently of the target branch — `BranchMerge` on the session branch would merge it into the default branch with no human review. The denylist tracks infrahub-sdk's built-in names and must be updated if the SDK adds more.
+- **Robust default-branch guard.** When `reset_session_branch` targets an existing branch, it checks the resolved branch's `is_default` flag, not just a name compare against the cached default — closing case/alias variants that an exact string match would miss.
+
+## Consequences
+
+### Positive
+
+- Merging the session branch no longer wedges writes — recovery is automatic and requires no restart (the original customer bug).
+- Sessions are isolated: a reset/recovery in one session never disturbs another.
+- No memory growth from accumulating session ids — entries die with the session.
+- The status check reuses the existing `branch.get()` round-trip, so the hot write path adds no extra calls.
+- Operators have an explicit escape hatch to reset or switch branches mid-session.
+- Writes cannot escape the session branch, and an agent cannot merge to / delete the default branch via `mutate_graphql` — the `propose_changes` review gate can no longer be bypassed.
+
+### Negative
+
+- `reset_session_branch` with a conformant name can create branches, a minor branch-sprawl vector (bounded only by the naming convention).
+- Fixed-name `branch_pattern` (no placeholders) cannot recover after a merge — the merged branch still occupies the name; the system returns a clear, actionable error directing the operator to use a `{hex}`/`{date}` pattern.
+- Removing `mutate_graphql`'s `branch` argument is a tool API contract change; callers that passed an explicit branch must switch the session via `reset_session_branch` instead.
+- The blocked-mutation denylist must be kept in sync with Infrahub-SDK built-ins (a maintenance cost; a new privileged mutation would not be blocked until added).
+
+### Neutral
+
+- Recovery is observable via the `ctx.warning` (old→new) and the tool result's `branch` field; the audit middleware records the enclosing tool call.
+- Per-session state keys on the session object rather than `ctx.session_id` (a string); the object is the natural weak-ref anchor and avoids a never-cleaned string-keyed dict.
+
+## Alternatives Considered
+
+### Keep the process-wide scalar, only add the merged-status check
+
+Fixes the merge bug but leaves the cross-session sharing problem (one session's branch visible to all). Rejected — the sharing is itself a latent correctness issue.
+
+### `dict[str, str]` keyed by `ctx.session_id`
+
+Per-session, but a string-keyed dict on the shared `AppContext` is never cleaned up — it grows unbounded over the process lifetime (every HTTP session mints a new id). FastMCP's `set_state`/`get_state` is per-request, not per-session, so it can't hold the branch across calls. Rejected in favor of `WeakKeyDictionary` keyed by the session object, which auto-evicts.
+
+### Reactive-only detection (catch the read-only error, recover, retry)
+
+Performs a doomed write first and relies on matching server error strings. Kept only as a defense-in-depth net for the TOCTOU window; the proactive `status` check is the primary mechanism.

--- a/dev/knowledge/architecture.md
+++ b/dev/knowledge/architecture.md
@@ -39,8 +39,11 @@ entries automatically when a session ends — no unbounded growth.
 single `client.branch.get()`: a `BranchNotFoundError` (deleted) or a
 `BranchStatus` of `MERGED`/`DELETING` (present but read-only) clears the entry
 and provisions a fresh branch, warning the caller with the old and new names.
-A read-only error surfacing during the write itself is also recovered (the
-session entry is cleared and a retryable error returned). `reset_session_branch`
+A read-only/merged error surfacing during the write is recovered too, but only
+after re-confirming via `branch.get()` that the branch is actually merged/deleted
+(so an unrelated read-only *attribute* error never clears a valid branch); on a
+confirmed-stale branch the session entry is cleared and a retryable error returned.
+`reset_session_branch`
 is the explicit operator override (reset to fresh, or switch to a named branch —
 created when the name matches `branch_pattern`). See
 [ADR 0007](../adr/0007-per-session-branch-recovery-and-reset.md).

--- a/dev/knowledge/architecture.md
+++ b/dev/knowledge/architecture.md
@@ -25,6 +25,26 @@ The server is built on **FastMCP** and follows its composition pattern:
 configuration are yielded as `AppContext`, available to all tools via
 FastMCP's dependency injection.
 
+### Session-branch state (per-session, weakly held)
+
+`AppContext` is shared across MCP sessions for the process lifetime, so the
+active session branch must **not** be a single value on it. Instead it is held
+in `WeakKeyDictionary` maps keyed by the per-session object
+(`ctx.request_context.session`, resolved by `_session_obj`): one map for the
+branch name, one for a per-session `asyncio.Lock`. This gives true per-session
+isolation (a reset/recovery in one session never touches another) and releases
+entries automatically when a session ends — no unbounded growth.
+
+`get_or_create_session_branch()` validates the cached branch before reuse via a
+single `client.branch.get()`: a `BranchNotFoundError` (deleted) or a
+`BranchStatus` of `MERGED`/`DELETING` (present but read-only) clears the entry
+and provisions a fresh branch, warning the caller with the old and new names.
+A read-only error surfacing during the write itself is also recovered (the
+session entry is cleared and a retryable error returned). `reset_session_branch`
+is the explicit operator override (reset to fresh, or switch to a named branch —
+created when the name matches `branch_pattern`). See
+[ADR 0007](../adr/0007-per-session-branch-recovery-and-reset.md).
+
 ## Middleware Stack
 
 Defined in `src/infrahub_mcp/middleware.py`. Composed once at startup

--- a/docs/docs/references/methods.mdx
+++ b/docs/docs/references/methods.mdx
@@ -125,6 +125,8 @@ Execute a read-only GraphQL query against Infrahub. Mutations are rejected at th
 
 Write tools target the **active session branch**, auto-created on the first write of a session (`mcp/session-YYYYMMDD-<hex>`). Use `propose_changes` to open a review once your changes are ready. Write tools are hidden when the server runs in read-only mode.
 
+The session branch is tracked per session. If it has been merged or deleted, the next write automatically recovers onto a fresh branch — no server restart is needed. Use `reset_session_branch` to reset or switch branches deliberately.
+
 <!-- vale off -->
 ### node_upsert
 <!-- vale on -->
@@ -203,9 +205,26 @@ Open a proposed change (pull request) from the active session branch to the defa
 - non-idempotent
 - potentially destructive
 
-Execute a GraphQL mutation against Infrahub — use only for complex writes that the typed tools can't express (relationship edits, bulk operations, mutations not covered by `node_upsert` / `node_delete`). The mutation targets the session branch by default.
+Execute a GraphQL mutation against Infrahub — use only for complex writes that the typed tools can't express (relationship edits, bulk operations, mutations not covered by `node_upsert` / `node_delete`). The mutation always runs on the active session branch; there is no branch override. To target a different branch deliberately, switch the session with `reset_session_branch` first. Branch-management mutations (`BranchMerge`, `BranchRebase`, `BranchDelete`, …) and schema mutations are rejected — they would bypass session isolation and the review gate.
 
 #### Parameters
 
-- **query** (string, required): GraphQL mutation to execute
-- **branch** (string): branch to execute against; defaults to the session branch
+- **query** (string, required): GraphQL mutation to execute on the session branch
+
+<!-- vale off -->
+### reset_session_branch
+<!-- vale on -->
+
+#### Capabilities
+
+- write
+- non-idempotent
+- non-destructive
+
+Reset or switch the active session branch for the current session. Call with no arguments to clear the cached branch so the next write creates a fresh one (for example, after merging your work). Pass a branch name to switch this session to it — the branch is created when it does not exist and the name matches the configured branch pattern. The instance default branch and merged or read-only branches are rejected. Affects only the calling session.
+
+A merged or deleted session branch is recovered automatically on the next write; this tool is the explicit override on top of that.
+
+#### Parameters
+
+- **branch** (string): target branch; omit to reset to a fresh auto-created branch

--- a/specs/archive/20260604-141223-session-branch-recovery/checklists/requirements.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Session Branch Recovery & Reset
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- Validation passed on first iteration.
+- `/speckit-clarify` (Session 2026-06-04) resolved 3 decisions into the spec: reset/override surface (single tool + optional branch), non-existent target-branch behavior (validate against `branch_pattern` → create + notify, else error), and session-branch scope (**per-session**, a change from today's process-wide cache).
+- One implementation choice remains deferred to planning (viable default, no scope impact): detection mechanism — proactive writability check vs. catching the read-only error on write.

--- a/specs/archive/20260604-141223-session-branch-recovery/contracts/mcp-tools.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/contracts/mcp-tools.md
@@ -1,0 +1,55 @@
+# Contracts: MCP Tool Interfaces
+
+The server's external interface is its MCP tools. This feature adds one tool and adjusts the behavioral contract of three existing entry points. Tool I/O is enforced by FastMCP schema generation from the Python signatures.
+
+## NEW tool: `reset_session_branch`
+
+- **Tags**: `{"session", "write"}` · **Annotations**: `readOnlyHint=False`, `idempotentHint=False`, `destructiveHint=False`
+- **Availability**: only when `read_only=false` (mounted in `write_mcp`; blocked by `ReadOnlyMiddleware` otherwise).
+
+**Input**
+| Param | Type | Default | Meaning |
+|---|---|---|---|
+| `branch` | `str \| None` | `None` | Omit → drop this session's cached branch (next write provisions a fresh one). Provide → switch this session to the named branch. |
+
+**Output** (`dict[str, Any]`)
+```jsonc
+{
+  "session_branch": "mcp/session-20260604-ab12cd34",  // active branch after the call, or null when reset-to-empty
+  "previous_branch": "mcp/session-20260603-deadbeef",  // what it was before, or null
+  "created": false,                                     // true when a new branch was provisioned by this call
+  "action": "reset" | "switched" | "created"           // what happened
+}
+```
+
+**Behavior / errors**
+| Case | Result |
+|---|---|
+| `branch=None` | clear this session's entry; `action="reset"`, `session_branch=null` |
+| `branch` exists, writable, non-default | switch session to it; `action="switched"` |
+| `branch` does not exist, **conforms** to `branch_pattern` | create it, switch session to it, inform caller; `action="created"`, `created=true` |
+| `branch` does not exist, **non-conformant** | `ToolError` — name does not match the configured convention; nothing created |
+| `branch` == instance default branch | `ToolError` (reuse `assert_writable_branch` message) |
+| `branch` exists but `status ∈ {MERGED, DELETING}` | `ToolError` — cannot target a read-only/merged branch |
+| isolation | only the calling session's entry changes; other sessions unaffected |
+
+## MODIFIED behavior: `get_or_create_session_branch` (internal, backs all write tools)
+
+- Returns `str` (unchanged signature). Now keyed by the per-session object (`_session_obj(ctx)`).
+- On a cached entry, validates via `client.branch.get()`:
+  - `BranchNotFoundError` → clear + recreate + `ctx.warning` naming old branch (existing).
+  - `status ∈ {MERGED, DELETING}` → clear + recreate + `ctx.warning` naming **old and new** branch (NEW — satisfies FR-002/FR-004/SC-005).
+  - writable → reuse.
+- Concurrency: serialized per session via that session's lock; concurrent writes in one session converge on one branch (FR-008).
+
+## MODIFIED output: `get_session_info`
+
+- `session_branch` / `has_session_branch` now reflect **the calling session's** branch (via `get_session_branch(ctx)`), not a process-global value. Output shape unchanged (backward compatible).
+
+## MODIFIED behavior: `propose_changes`
+
+- Reads the **calling session's** branch via `get_session_branch(ctx)`. Same "no active session branch" error when the session has none. No signature/output change.
+
+## Unchanged
+
+- `node_upsert`, `node_delete`, `mutate_graphql` signatures are unchanged; they inherit recovery transparently through `get_or_create_session_branch`. `mutate_graphql`'s existing explicit `branch` param keeps its current semantics (targets an existing branch; default-branch protection preserved).

--- a/specs/archive/20260604-141223-session-branch-recovery/contracts/mcp-tools.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/contracts/mcp-tools.md
@@ -50,6 +50,10 @@ The server's external interface is its MCP tools. This feature adds one tool and
 
 - Reads the **calling session's** branch via `get_session_branch(ctx)`. Same "no active session branch" error when the session has none. No signature/output change.
 
+## MODIFIED behavior: `mutate_graphql`
+
+- The explicit `branch` parameter is **removed** — like `node_upsert`/`node_delete`, the mutation always targets the active session branch (switch deliberately via `reset_session_branch`). Branch-management (`Branch*`) and schema (`Schema*`) mutations, and non-mutation operations, are rejected so writes cannot bypass the review gate.
+
 ## Unchanged
 
-- `node_upsert`, `node_delete`, `mutate_graphql` signatures are unchanged; they inherit recovery transparently through `get_or_create_session_branch`. `mutate_graphql`'s existing explicit `branch` param keeps its current semantics (targets an existing branch; default-branch protection preserved).
+- `node_upsert` and `node_delete` signatures are unchanged; they inherit recovery transparently through `get_or_create_session_branch`.

--- a/specs/archive/20260604-141223-session-branch-recovery/critique.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/critique.md
@@ -1,0 +1,51 @@
+# Critique: Session Branch Recovery & Reset (spec + plan)
+
+Adversarial review through engineering and product lenses. Date 2026-06-04. Severity: 🔴 high / 🟠 medium / 🟡 low.
+
+## Engineering lens
+
+### 🔴 E1 — The per-session `dict` on the shared `AppContext` leaks and has no cleanup hook
+The plan replaces the scalar `session_branch` with `session_branches: dict[str, str]` + `_session_locks: dict[str, asyncio.Lock]` keyed by `ctx.session_id`, stored on the **process-wide** `AppContext` (which the #110 bug confirms is shared across sessions). Nothing ever removes entries. Over the life of a streamable-HTTP server, every new MCP session mints a new `session_id` → both dicts grow **unbounded**. The old scalar had no such issue.
+
+- Evidence: FastMCP's own per-session store doesn't help — `ctx.set_state/get_state` write to `self._request_state` (`fastmcp/server/context.py:207,1264`), which is **per-request (per Context)**, not per-session, so it can't hold the branch across tool calls. No session-close callback is exposed that maps to our dict (only a generic `finally` in `mcp/server/lowlevel/server.py:776` unwinding the lifespan stack — which does not touch a dict on the shared `AppContext`).
+- **Recommendation**: don't hand-manage a `dict`. Either (a) store the branch on the **per-session object** that gets GC'd when the session ends — mirror FastMCP's own trick (`session._fastmcp_state_prefix`) by stashing on `ctx.request_context.session`; or (b) use a `weakref.WeakKeyDictionary` keyed by that session object on `AppContext`. Both auto-evict on session teardown, give true per-session isolation, and remove the lock-dict bookkeeping. Update `data-model.md` + plan step 1.
+
+### 🟠 E2 — TOCTOU window leaves the customer's exact error reachable; plan marks the fix "optional"
+Proactive `status` check happens during `branch.get()`, then the write happens. If the branch is merged in that window, the write fails with the very `"has been merged and is read-only"` error this feature exists to eliminate. `research.md`/`plan.md` label the reactive catch as "optional hardening."
+- **Recommendation**: make the reactive net **required**, not optional — on write paths, catch `GraphQLError` matching `read-only`/`has been merged`, clear the session entry, and recover (or at minimum return an actionable "retry — branch was merged" error). For a bug-fix whose success criterion (SC-001) is "next write succeeds," leaving the window open is under-committing.
+
+### 🟠 E3 — Breaking change to `AppContext` not fully called out
+Removing the `session_branch` field changes the dataclass constructor. The existing `tests/unit/test_session_branch_validation.py` constructs `AppContext(..., session_branch="…")` and asserts on `app_ctx.session_branch` (lines 34, 45–47, 52, 64, 70, 81). These won't just be "extended" — they break to compile/run. Plan should explicitly list: field removal + every reader migrated (`utils`, `session.py`, `write.py:275`) + test rewrite, so `/speckit-tasks` doesn't under-scope.
+
+### 🟠 E4 — `branch_name_conforms` regex-from-pattern is error-prone
+`{user}` is mapped to `[A-Za-z0-9._/-]+`, which includes `/` and is greedy — for a pattern like `mcp/{user}/work-{hex}` it can swallow literal separators, and adjacent placeholder/literal boundaries are tricky to anchor. Risk of both false accepts and false rejects.
+- **Recommendation**: build the regex from `string.Formatter().parse()` output (reuse the parsing already in `config._validate_branch_pattern`), escape literals with `re.escape`, use **non-greedy** placeholder classes, anchor `^…$`, and cover it with parametrized tests including adjacent-placeholder cases. Or simplify the rule (e.g., require the configured static prefix + valid charset) if full shape-matching proves brittle.
+
+### 🟡 E5 — `NEED_REBASE`/`NEED_UPGRADE_REBASE` assumed writable without evidence
+Treated as "writable" in `data-model.md` with no citation. Plausible but unverified — confirm a rebase-pending branch still accepts writes before relying on it.
+
+## Product lens
+
+### 🔴 P1 — Per-session scoping (FR-010) is scope/risk beyond the reported bug
+The customer's actual failure is only the merged-branch staleness (symptoms 1–3), all fixed by **US1 auto-recovery** alone. Per-session scoping is a larger refactor of the state model (and the source of E1). It was a deliberate clarify choice, but it shouldn't gate the customer fix.
+- **Recommendation**: ship in two slices. Slice 1 = US1 auto-recovery (merged/deleting → recover) on the existing scalar — small, low-risk, unblocks the customer immediately. Slice 2 = reset tool + per-session scoping (US2/US3/FR-010) with the E1 weakref design. The plan already names US1 the MVP; make the split explicit so Slice 1 can merge without waiting on the riskier refactor.
+
+### 🟠 P2 — SC-002 "100% of write entry points recover" overclaims
+`mutate_graphql` with an explicit `branch` (pre-existing param) bypasses `get_or_create_session_branch`, so it gets no recovery and no status check. SC-002 as written is false for that path.
+- **Recommendation**: either scope SC-002 to "session-branch-routed writes," or extend recovery/validation to the explicit-branch path too (and decide what "recover" means when the user named the branch).
+
+### 🟠 P3 — `reset_session_branch` name undersells switch/create
+One verb "reset" now also switches to and creates branches (Q1/Q2). An agent reading the tool name may not discover the override/create behavior.
+- **Recommendation**: reconsider the name (`set_session_branch` / `switch_session_branch`) or, if keeping `reset`, make the tool description + the `server.py` system prompt explicitly state the three behaviors and when to use each.
+
+### 🟡 P4 — Auto-create-on-conformant enables branch sprawl
+An agent can call `reset_session_branch("<conformant-name>")` repeatedly and create unlimited branches. There's no cap (`max_branch_retries` only bounds collision retries).
+- **Recommendation**: accept the risk (conformance is the guard) but note it; or add a soft cap / require the branch to not already be "many". At least document it.
+
+### 🟡 P5 — Silent branch switch needs an audit trail
+Recovery swaps the working branch under the agent. `ctx.warning` informs the live caller, but the human reviewing the eventual proposed change should see provenance.
+- **Recommendation**: ensure the audit middleware records recovery/switch events (old→new), not just a transient warning.
+
+## Verdict
+
+The plan is directionally sound and the MVP sequencing is right, but **E1 (leak) and E2 (TOCTOU) are design-level and should be fixed in plan/data-model before `/speckit-tasks`**, and **P1 (slice the per-session refactor out of the customer fix)** is the highest-leverage product call. E3 affects task scoping. The rest are refinements.

--- a/specs/archive/20260604-141223-session-branch-recovery/data-model.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/data-model.md
@@ -1,0 +1,97 @@
+# Phase 1 Data Model: Session Branch Recovery & Reset
+
+This feature has no persistent storage. The "data model" is the in-memory state on `AppContext` and the value objects derived from the Infrahub SDK.
+
+## Entity: Per-session branch registry (replaces `AppContext.session_branch`)
+
+`AppContext` (`src/infrahub_mcp/utils.py`) changes from a single scalar to a per-session map.
+
+**Before**
+```python
+session_branch: str | None = field(default=None)
+_session_branch_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+```
+
+**After** (keyed by the per-session OBJECT via weak references — auto-evicts at session end; see research R2 / critique E1)
+```python
+from weakref import WeakKeyDictionary
+# key type is the MCP ServerSession object (ctx.request_context.session); duck-typed at runtime
+_session_branches: "WeakKeyDictionary[Any, str]" = field(default_factory=WeakKeyDictionary)
+_session_locks: "WeakKeyDictionary[Any, asyncio.Lock]" = field(default_factory=WeakKeyDictionary)
+_session_locks_guard: asyncio.Lock = field(default_factory=asyncio.Lock)
+```
+
+- `default_branch` + `_default_branch_lock` are **unchanged** (the default branch is instance-wide).
+- The scalar `session_branch` and `_session_branch_lock` are **removed** (see Breaking change below).
+- Keyed by the session object → a session has **at most one** active branch, and the entry is released when the session object is GC'd (no unbounded growth — FR-010).
+- Invariant: only `get_or_create_session_branch` / `reset_session_branch` mutate `_session_branches`, always while holding that session's lock.
+
+⚠️ **Breaking change (critique E3)**: removing the `session_branch` field changes the `AppContext` constructor. Every reader migrates (see table below) and the existing tests in `tests/unit/test_session_branch_validation.py` that pass `session_branch=` and assert on `app_ctx.session_branch` (lines 34, 45–47, 52, 64, 70, 81) must be rewritten to seed/inspect via the new per-session helpers.
+
+## Value object: Session key (the session object)
+
+Storage keys on the per-session object directly; no string key is derived for storage:
+
+```python
+def _session_obj(ctx: Context) -> Any:
+    rc = ctx.request_context
+    if rc is None or getattr(rc, "session", None) is None:
+        msg = "request_context.session must not be None"
+        raise RuntimeError(msg)
+    return rc.session
+```
+
+- `ctx.request_context.session` is the same object across tool calls within one client session and distinct per session (stdio/SSE/HTTP); weak-referenceable + identity-hashable → valid `WeakKeyDictionary` key.
+- `ctx.session_id` (str) remains available for **display/logging** in `get_session_info`, not for storage.
+
+## Value object: Branch writability (derived from `BranchData.status`)
+
+Classification used by recovery. No new type required — read `branch.status` directly.
+
+| Source signal | Classification | Action |
+|---|---|---|
+| `BranchNotFoundError` from `branch.get()` | **Missing** (deleted) | clear cache, recreate (existing behavior) |
+| `status == BranchStatus.MERGED` | **Unwritable** (read-only) | clear cache, recreate, warn (NEW) |
+| `status == BranchStatus.DELETING` | **Unwritable** | clear cache, recreate, warn (NEW) |
+| `status ∈ {OPEN, NEED_REBASE, NEED_UPGRADE_REBASE}` | **Writable** | reuse cached branch |
+
+Constant: `_UNWRITABLE_STATUSES = {BranchStatus.MERGED, BranchStatus.DELETING}`.
+
+## Validation rule: explicit target-branch conformance (Q2 / FR-006)
+
+```python
+def branch_name_conforms(name: str, pattern: str) -> bool
+```
+
+- Returns True iff `name` matches the regex derived from `pattern` (placeholders → `{date}=\d{8}`, `{hex}=[0-9a-f]{8}`, `{user}=[A-Za-z0-9._/-]+?`; literals escaped; anchored). Fixed pattern → exact match.
+- **Build it robustly (critique E4)**: derive the regex from `string.Formatter().parse(pattern)` (same parser `config._validate_branch_pattern` uses), `re.escape` each literal segment, use **non-greedy** placeholder classes, and anchor `^…$`. Greedy `{user}` (which allows `/`) can otherwise swallow literal separators in patterns like `mcp/{user}/{hex}`. Cover adjacent-placeholder/boundary cases in parametrized tests.
+- Name must also satisfy the allowed branch charset (alphanumeric, `-`, `_`, `.`, `/`); reuse/extend the rules already in `auth.sanitize_user_for_branch`.
+
+## State transitions: a session's branch over its lifecycle
+
+```
+(no key)
+   │  first write  →  create branch (pattern)            ─┐
+   ▼                                                       │ session_branches[key] = "mcp/session-…"
+[active: writable]
+   │  next write, branch still OPEN/NEED_REBASE  → reuse
+   │  next write, branch MERGED/DELETING/missing → recover: del key, create new, warn (old→new)
+   │  reset_session_branch()           → del key (next write provisions fresh)
+   │  reset_session_branch("feat/x")   → branch exists+writable → key = "feat/x"
+   │                                   → branch missing + conformant → create, key = "feat/x", inform
+   │                                   → branch missing + non-conformant → ToolError, no change
+   │                                   → branch is default / merged → ToolError (reject)
+   ▼
+[active: new branch]
+```
+
+## Touched readers (must become session-aware)
+
+| Reader | File | Change |
+|---|---|---|
+| `get_or_create_session_branch` | `utils.py:191` | key by `_session_obj`; per-session lock; add `status` check + reactive read-only catch (FR-011) |
+| `get_session_branch` (NEW, no-create reader) | `utils.py` | `return app_ctx._session_branches.get(_session_obj(ctx))` |
+| `get_session_info` | `tools/session.py:37` | read via `get_session_branch(ctx)` |
+| `propose_changes` | `tools/write.py:275` | read via `get_session_branch(ctx)` instead of `app_ctx.session_branch` |
+| `reset_session_branch` (NEW tool) | `tools/write.py` | mutate this session's entry (`_session_branches[_session_obj(ctx)]`) |
+| `node_upsert` / `node_delete` / `mutate_graphql` (default path) | `tools/write.py` | wrap SDK write to catch read-only/merged `GraphQLError` → clear entry + retryable error (FR-011) |

--- a/specs/archive/20260604-141223-session-branch-recovery/plan.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Session Branch Recovery & Reset
+
+**Branch**: `feat/session-branch-recovery` | **Date**: 2026-06-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/20260604-141223-session-branch-recovery/spec.md`
+
+## Summary
+
+Close the two remaining gaps in session-branch handling left open after PR #110:
+
+1. **Auto-recover** writes when the cached session branch is no longer writable — not just *deleted* (`BranchNotFoundError`, already handled) but also *merged / being deleted*. Detect proactively via `BranchData.status` on the `branch.get()` call the code already makes (zero extra round-trip), clear the cache, recreate, and warn naming old→new branch.
+2. **Reset / override** the session branch via one new write-tagged tool `reset_session_branch(branch=None)`, and **scope the session branch per MCP session** (`ctx.session_id`) instead of process-wide, so reset/recovery never disturbs other sessions. Targeting a non-existent name is allowed only when it conforms to the configured `branch_pattern` (then created + reported), else an actionable error.
+
+Implementation is concentrated in `utils.py` (state model + recovery + helpers), `tools/write.py` (new tool + `propose_changes` reader), and `tools/session.py` (session-aware read), with extended unit tests.
+
+## Technical Context
+
+**Language/Version**: Python 3.13.5
+**Primary Dependencies**: fastmcp 3.2.4, infrahub-sdk 1.20.0, pydantic 2 / pydantic-settings, Starlette
+**Storage**: N/A (in-memory session state on `AppContext`)
+**Testing**: pytest + pytest-asyncio (`tests/unit/`), AsyncMock of the SDK client
+**Target Platform**: Python MCP server (stdio + streamable-HTTP transports)
+**Project Type**: Single project (MCP server library) — `src/infrahub_mcp/`
+**Performance Goals**: No added round-trips on the hot write path (status check reuses the existing `branch.get()`); per-session locking must not serialize unrelated sessions
+**Constraints**: Recovery without server restart; per-session isolation; per-session state auto-released at session end (no unbounded growth); never write to the default branch; mypy-clean, no `Any` at public interfaces
+**Scale/Scope**: Small, focused change — ~3 source files + tests + docs/ADR. No new dependencies.
+
+### Resolved unknowns (see [research.md](./research.md))
+
+- **Detection** → proactive via `BranchData.status ∈ {MERGED, DELETING}` (+ existing `BranchNotFoundError`). Reactive `read-only`/`has been merged` error catch is **required** for the TOCTOU window (FR-011): clear the cached branch + raise a retryable error; never blindly replay an arbitrary mutation.
+- **Per-session storage** → `WeakKeyDictionary` keyed by the session object (`ctx.request_context.session`) on the shared `AppContext` — auto-evicts at session end (no leak; critique E1), correct regardless of lifespan scope. `ctx.session_id` used only for display.
+- **Conformance** → regex derived from `branch_pattern` via `string.Formatter().parse` + `re.escape` + non-greedy classes (critique E4).
+
+## Constitution Check
+
+*GATE: must pass before Phase 0 (done) and re-checked after Phase 1 design (done — still passing).*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. MCP Protocol Compliance | ✅ | New tool registered via existing `write_mcp` composition; tagged `"write"`; standard `ToolError` messages, no internal leakage. |
+| II. Infrahub SDK Integration | ✅ | All branch ops via `client.branch.*` (`get`, `create`); no raw HTTP. |
+| III. Branch-Safe by Default | ✅ | `assert_writable_branch` reused for explicit target; default branch never written; explicit names validated against `branch_pattern` + allowed charset. |
+| IV. Type Safety & Explicit Contracts | ✅ | Full annotations; `dict[str, str]` / `str \| None`; no `Any` at public interfaces; mypy gate. |
+| V. Test Discipline | ✅ | Extend `tests/unit/test_session_branch_validation.py` + new tool test module; parametrized; pytest-asyncio. |
+| VI. Security & Input Boundaries | ✅ | Tool input validated (charset + conformance) before SDK; no secrets/internals in errors; per-request client unchanged. |
+| VII. Simplicity & Maintainability | ⚠️→✅ | Per-session `dict` adds minor state vs a scalar, but is **required** by FR-010 and is the simplest design satisfying it; status check reuses the existing call. No new dependency, no new abstraction layer. |
+
+**Gate result: PASS — no violations.** Complexity Tracking table not required.
+
+> Architecture/UX changes trigger constitution doc duties: the per-session scoping change updates `dev/knowledge/` and warrants a short `dev/adr/` entry; the new tool is user-facing → `docs/docs/`. These are enumerated as tasks in `/speckit-tasks`. AGENTS.md flags "modifying per-request state model" as *Ask First* — confirm the per-session approach with a maintainer at PR time.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/20260604-141223-session-branch-recovery/
+├── plan.md            # this file
+├── spec.md
+├── research.md        # Phase 0
+├── data-model.md      # Phase 1
+├── quickstart.md      # Phase 1
+├── contracts/
+│   └── mcp-tools.md   # Phase 1
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+src/infrahub_mcp/
+├── utils.py              # AppContext state model; get_or_create_session_branch (status check + per-session key);
+│                         #   NEW: _session_obj, _get_session_lock, get_session_branch, clear_session_branch, branch_name_conforms, _UNWRITABLE_STATUSES
+├── tools/
+│   ├── write.py          # NEW reset_session_branch tool; propose_changes → session-aware reader
+│   └── session.py        # get_session_info → session-aware reader
+└── (config.py, auth.py, server.py — read/reuse only; auth charset rules reused)
+
+tests/
+└── unit/
+    ├── test_session_branch_validation.py   # extend: merged/deleting recovery, per-session keying
+    └── test_reset_session_branch.py        # NEW: reset/switch/create/error/reject/isolation
+
+docs/docs/ (+ dev/knowledge/, dev/adr/)     # user doc + architecture note + ADR
+```
+
+**Structure Decision**: Single-project layout (existing `src/infrahub_mcp/`). Changes localize to the three files that touch session-branch state; all write tools inherit recovery via the shared `get_or_create_session_branch`.
+
+## Phase 0 — Outline & Research
+
+Complete. See [research.md](./research.md): R1 detection mechanism, R2 per-session identity + lifespan-scope ambiguity, R3 conformance validation, R4 tool placement/tagging. All `NEEDS CLARIFICATION` resolved.
+
+## Phase 1 — Design & Contracts
+
+Complete:
+
+- [data-model.md](./data-model.md) — `AppContext` map model, session-key value object, writability classification (`status`), conformance rule, state transitions, touched readers.
+- [contracts/mcp-tools.md](./contracts/mcp-tools.md) — `reset_session_branch` I/O + error matrix; behavioral deltas for `get_or_create_session_branch`, `get_session_info`, `propose_changes`.
+- [quickstart.md](./quickstart.md) — manual scenarios A–D + verification gates.
+- Agent context (`AGENTS.md` SPECKIT block) updated to point at this plan.
+
+### Implementation outline (for `/speckit-tasks`)
+
+1. **State model** (`utils.py`): **remove** the `session_branch` field + `_session_branch_lock` (breaking change — migrate all readers and the existing tests, critique E3). Add `_session_branches`/`_session_locks` as `WeakKeyDictionary` keyed by the session object + `_session_locks_guard`. Add `_session_obj(ctx)`, a `_get_session_lock` helper, and `get_session_branch(ctx)`.
+2. **Recovery** (`utils.py` + write paths): in `get_or_create_session_branch`, key by `_session_obj`; add `_UNWRITABLE_STATUSES = {MERGED, DELETING}`; on a cached entry, inspect `branch.get().status` and recover (warn old→new) in addition to `BranchNotFoundError`. Add the **required** FR-011 reactive net on `node_upsert`/`node_delete`/`mutate_graphql` (default path): catch read-only/merged `GraphQLError` → clear the session entry → raise a retryable `ToolError`.
+3. **Conformance helper** (`utils.py`): `branch_name_conforms(name, pattern)` (regex from pattern + charset check).
+4. **New tool** (`tools/write.py`): `reset_session_branch(branch=None)` tagged `{"session","write"}`; implement the error matrix from the contract; reuse `assert_writable_branch`, `get_default_branch`, branch-create helpers.
+5. **Session-aware readers**: `get_session_info` (session.py) and `propose_changes` (write.py) read via `get_session_branch(ctx)`. Update the system prompt in `server.py` to mention `reset_session_branch`.
+6. **Tests**: extend + new module per quickstart (TDD — write failing tests first).
+7. **Docs/ADR**: user doc for the tool; `dev/knowledge/` architecture note; short ADR on per-session scoping + proactive status detection.
+
+## Complexity Tracking
+
+No constitution violations — table intentionally omitted.

--- a/specs/archive/20260604-141223-session-branch-recovery/quickstart.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/quickstart.md
@@ -17,7 +17,7 @@ How to exercise the feature once implemented.
 
 ## Scenario C — switch/override to a named branch
 
-1. Call `reset_session_branch(branch="mcp/session-20260604-feature1")` (a name that conforms to `branch_pattern` but doesn't exist).
+1. Call `reset_session_branch(branch="mcp/session-20260604-deadbeef")` (a name that conforms to `branch_pattern` but doesn't exist).
    - **Expected**: branch created, session switched, `{"action":"created","created":true,...}`.
 2. Call `reset_session_branch(branch="totally-random-name")` (non-conformant).
    - **Expected**: `ToolError` explaining the name doesn't match the configured convention; nothing created.

--- a/specs/archive/20260604-141223-session-branch-recovery/quickstart.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/quickstart.md
@@ -1,0 +1,43 @@
+# Quickstart: Session Branch Recovery & Reset
+
+How to exercise the feature once implemented.
+
+## Scenario A — auto-recovery after merge (the customer's bug)
+
+1. Start the server (write mode) against a dev Infrahub.
+2. Do a write (e.g. `node_upsert`) → a session branch `mcp/session-…` is created. Confirm via `get_session_info`.
+3. Merge that branch into `main` (web UI or proposed change). The branch now has `status=MERGED` and is read-only — it still exists.
+4. **Without restarting the server**, do another write.
+   - **Expected**: the write succeeds on a *new* `mcp/session-…` branch; the response/log names the old (merged) branch and the new one. No "has been merged and is read-only" error.
+
+## Scenario B — manual reset
+
+1. With an active session branch, call `reset_session_branch()` (no args). → `{"action":"reset","session_branch":null,...}`.
+2. Next write provisions a fresh branch.
+
+## Scenario C — switch/override to a named branch
+
+1. Call `reset_session_branch(branch="mcp/session-20260604-feature1")` (a name that conforms to `branch_pattern` but doesn't exist).
+   - **Expected**: branch created, session switched, `{"action":"created","created":true,...}`.
+2. Call `reset_session_branch(branch="totally-random-name")` (non-conformant).
+   - **Expected**: `ToolError` explaining the name doesn't match the configured convention; nothing created.
+3. Call `reset_session_branch(branch="main")` (default).
+   - **Expected**: rejected with the default-branch protection message.
+
+## Scenario D — per-session isolation
+
+1. Open two MCP client sessions (distinct `mcp-session-id`).
+2. Each does a write → each gets its **own** session branch.
+3. Session 1 calls `reset_session_branch()`.
+   - **Expected**: session 2's branch is unchanged; its next write still targets its original branch.
+
+## Verification (gates)
+
+```bash
+uv sync
+uv run pytest tests/unit/test_session_branch_validation.py -x   # targeted
+uv run invoke format lint                                       # ruff + mypy + pylint + yaml
+uv run pytest                                                   # full suite
+```
+
+Tests to add/extend in `tests/unit/test_session_branch_validation.py` (+ a new test module for the tool): merged-status recovery, DELETING-status recovery, deleted-branch recovery (regression), reset-to-empty, switch-to-existing, create-on-conformant, error-on-nonconformant, reject-default, and per-session isolation.

--- a/specs/archive/20260604-141223-session-branch-recovery/research.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/research.md
@@ -1,0 +1,40 @@
+# Phase 0 Research: Session Branch Recovery & Reset
+
+All `NEEDS CLARIFICATION` items from Technical Context are resolved below. Findings come from the installed packages in this repo's venv (`fastmcp==3.2.4`, `infrahub-sdk==1.20.0`, Python 3.13.5) and the existing source.
+
+## R1 — Detecting a merged / read-only branch (resolves the deferred "detection mechanism" decision)
+
+- **Decision**: Detect **proactively** by inspecting `BranchData.status` returned from the `client.branch.get()` call that `get_or_create_session_branch` already performs. Treat `status ∈ {MERGED, DELETING}` as "unwritable → recover" and `BranchNotFoundError` as "missing → recover" (existing behavior). `OPEN`, `NEED_REBASE`, `NEED_UPGRADE_REBASE` remain writable.
+- **Rationale**:
+  - `infrahub_sdk/branch.py` defines `class BranchStatus(str, Enum)` with `OPEN, NEED_REBASE, NEED_UPGRADE_REBASE, DELETING, MERGED`, and `BranchData.status: BranchStatus` (default `OPEN`). When a branch is merged its `status` becomes `MERGED`. This is the **only** field that reliably indicates read-only state (the other fields — `is_default`, `sync_with_git`, `has_schema_changes`, `graph_version` — do not flip on merge).
+  - The #110 fix already calls `await client.branch.get(branch_name=...)` on every write to validate existence. Reading `.status` from that same response adds **zero** extra round-trips — it is the cheapest possible mechanism and fits Principle VII (Simplicity).
+- **Reactive net (REQUIRED — FR-011, raised from "optional" by critique E2)**: A merge can happen in the TOCTOU window between `branch.get()` and the actual write. The write paths catch a read-only/merged-looking `GraphQLError` (substring pre-filter) and then **confirm the branch is actually MERGED/DELETING/missing via `client.branch.get()` before clearing** — a substring match alone is a false-positive risk (a read-only *attribute* error reads identically and would wrongly orphan the user's work; this was caught in code review). Only on confirmed staleness do they clear the cached branch (under the per-session lock) and raise an actionable retryable `ToolError`. We deliberately do **not** blindly replay the failed mutation — an arbitrary `mutate_graphql` could partially apply. Clearing + retryable error guarantees the session never stays wedged (SC-001).
+- **Alternatives considered**:
+  - *Reactive-only* (catch the write error, recover, retry): works but performs a doomed write first, and matching server error strings is brittle. Rejected as the primary mechanism; kept only as the optional net above.
+  - *A dedicated writability endpoint*: none exists on `client.branch.*` (`get`, `all`, `create`, `delete`, `rebase`, `validate`, `merge`, `diff_data`).
+
+## R2 — Per-session scoping, identity & cleanup (resolves FR-010 / Q3; revised by critique E1)
+
+- **Decision**: Store the session branch **keyed by the per-session object** (`ctx.request_context.session`) in `weakref.WeakKeyDictionary` maps on the (shared) `AppContext` — one for the branch name, one for the per-session lock — plus a small guard lock for lazy lock creation. The scalar `session_branch: str | None` is removed.
+- **Why the session OBJECT, not the `session_id` string (critique E1)**: a `dict[str, str]` keyed by `session_id` on the process-wide `AppContext` would **never be cleaned up** — every HTTP session mints a new id, so the dict grows unbounded for the server's life. There is no session-close hook that maps to such a dict (FastMCP's `ctx.set_state/get_state` is **per-request** — `_request_state`, `fastmcp/server/context.py:207,1264` — not per-session). A `WeakKeyDictionary` keyed by the session object **auto-evicts** when that session object is garbage-collected at session end → true per-session scope (FR-010) with no leak and no manual bookkeeping. FastMCP itself stashes per-session data on the session object (`session._fastmcp_state_prefix`, context.py:686), so the object is the natural per-session anchor.
+- **Identity properties**: `ctx.request_context.session` is the **same object** across all tool calls within one client session and a **distinct object** per session (confirmed in `mcp/shared/context.py` `RequestContext.session`; FastMCP wraps it). ServerSession instances are normal objects → weak-referenceable and identity-hashable, so they work as `WeakKeyDictionary` keys. (`ctx.session_id` is still fine for **display/logging** in `get_session_info`, but not used as a storage key.)
+- **Lifespan-scope ambiguity, intentionally sidestepped**: the MCP low-level layer enters the lifespan per session (`mcp/server/lowlevel/server.py:657`), but FastMCP caches the result process-wide (`_lifespan_result`); #110's commit message + the reported bug confirm `AppContext` is in practice **shared across sessions**. Keying by the session object is correct under either scope.
+- **Fallback / guard**: if `ctx.request_context` or its `session` is `None` (should not happen from a tool call), raise the existing `request_context must not be None` error.
+- **Alternatives considered**:
+  - *`dict[str, str]` keyed by `ctx.session_id`*: rejected — unbounded growth / leak (critique E1).
+  - *Stash the branch as an attribute directly on the session object*: viable (mirrors FastMCP) and also auto-cleans, but monkey-patches a third-party object and is harder to introspect/test; `WeakKeyDictionary` keeps state on our `AppContext`.
+  - *Rely on a fresh per-session `AppContext`*: rejected — contradicted by the observed bug and `_lifespan_result` caching.
+
+## R3 — Validating an explicit target branch name against the convention (resolves Q2 / FR-006)
+
+- **Decision**: A target branch name "conforms to the convention" iff it matches a regex derived from the configured `branch_pattern`. Build the regex by escaping the literal segments and substituting placeholders: `{date}→\d{8}`, `{hex}→[0-9a-f]{8}`, `{user}→[A-Za-z0-9._/-]+` (the sanitized-user charset), anchored `^…$`. If `branch_pattern` has no placeholders (fixed name), conformance means an exact match to that name. The name must additionally pass the allowed branch charset (Principle III: alphanumeric, hyphen, underscore, dot, slash). Conformant → create + tell the caller; non-conformant → `ToolError` with guidance; never silently reroute.
+- **Rationale**: `ServerConfig.branch_pattern` (default `mcp/session-{date}-{hex}`) is the single source of truth for naming, already validated for allowed placeholders (`config.py:_validate_branch_pattern`). `expand_branch_pattern` (utils.py) defines the exact placeholder semantics the regex mirrors (`%Y%m%d` → 8 digits; `secrets.token_hex(4)` → 8 lowercase hex). Deriving the matcher from the same pattern keeps generation and validation consistent.
+- **Alternatives considered**:
+  - *Accept any valid branch name*: rejected — the user explicitly asked to enforce the env-configured convention.
+  - *Require an exact placeholder re-expansion match*: impossible (`{hex}`/`{date}` are non-deterministic); regex shape-matching is the correct equivalent.
+
+## R4 — Tool placement, tagging, and read-only behavior
+
+- **Decision**: Add one new tool `reset_session_branch(branch: str | None = None)` in `tools/write.py`, tagged `{"session", "write"}` with `ToolAnnotations(readOnlyHint=False)`. It is mounted only when not in read-only mode (it lives in `write_mcp`, already gated in `server.py:257`). `get_session_info` (read tool) stays in `tools/session.py`.
+- **Rationale**: It mutates session state and may create a branch → it is a write operation; Principle I + AGENTS.md require write tools to be tagged `"write"` and the `ReadOnlyMiddleware` blocks them under `read_only=true`. Keeping it in `write_mcp` reuses the existing composition + gating.
+- **Alternatives considered**: putting it in `session.py` (read sub-app) — rejected, would expose a mutating tool in read-only mode.

--- a/specs/archive/20260604-141223-session-branch-recovery/spec.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/spec.md
@@ -1,0 +1,131 @@
+# Feature Specification: Session Branch Recovery & Reset
+
+**Feature Branch**: `feat/session-branch-recovery`  
+**Created**: 2026-06-04  
+**Status**: Completed  
+**Input**: User description: "Treat a merged/read-only session branch the same as a missing one (check writability on validation or catch the read-only error on write, clear the cache, recreate); and give a way to reset/override the session branch. Add tests to confirm this use case is covered."
+
+## Context & Problem
+
+The MCP server caches one **session branch** per server process, lazily created on the first write. It is reused for every subsequent write until the process restarts.
+
+Today the cache is only invalidated when the cached branch has been **deleted** (a "branch not found" condition). But in Infrahub a branch that has been **merged** is *not* deleted — it continues to exist as a **read-only** branch. So when an operator merges the session branch (the intended end-of-work action), the cache validation still sees the branch as present and keeps reusing it. Every subsequent write is then routed to a branch that rejects writes, producing errors like `Branch ... has been merged and is read-only`, and there is no in-session way to point writes at a different branch. The write path is effectively wedged until the server restarts.
+
+This was partially addressed previously (stale **deleted** branches are now recovered), but the **merged / read-only** case and the **manual reset** case remain open. This specification covers closing both gaps and adding regression tests.
+
+## Clarifications
+
+### Session 2026-06-04
+
+- Q: How should the manual reset/override capability be exposed? → A: A single write-tagged tool (e.g. `reset_session_branch`) with an optional `branch` argument — omit it to drop the cache and provision a fresh auto branch on the next write; pass a name to switch the current session to that branch.
+- Q: When a write or reset targets a branch name that does not yet exist, what should happen? → A: Validate the requested name against the configured branch naming convention (`branch_pattern`); if it conforms, create the branch and explicitly tell the caller it was created; if it does not conform, return an actionable error and create nothing.
+- Q: What scope should the session branch / reset / recovery have, given the cache is currently process-wide? → A: Per-session — the session branch is scoped to each MCP session/connection, so recovery and reset affect only the calling session and never disturb other concurrent sessions on the same process.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Writes auto-recover after the session branch is merged or becomes read-only (Priority: P1)
+
+An operator finishes a batch of changes on the auto-created session branch and merges it (the expected workflow). They then continue working in the same session and issue another write. Instead of failing, the write succeeds on a freshly provisioned session branch.
+
+**Why this priority**: This is the customer-blocking defect. Merging the session branch is the *normal, correct* end-of-work step, yet it currently wedges every subsequent write for the lifetime of the server process. Fixing this restores the core write workflow and closes the reported symptoms #1 (mutations rejected as read-only) and #3 (branch-creating mutations also rejected because they route to the dead branch).
+
+**Independent Test**: Simulate a session whose cached branch has been merged (exists but read-only). Issue any write. Verify the write completes successfully on a new branch and the old branch name is no longer used — without restarting the server.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cached session branch that has been merged and is read-only, **When** the operator issues a node create/update, **Then** the cache is cleared, a new writable session branch is provisioned, and the write succeeds on the new branch.
+2. **Given** a cached session branch that has been merged and is read-only, **When** the operator issues a GraphQL mutation with no explicit branch, **Then** the mutation succeeds on a newly provisioned branch.
+3. **Given** a cached session branch that has been deleted, **When** the operator issues a write, **Then** recovery behaves identically to the merged case (existing behavior preserved — regression guard).
+4. **Given** a write was rerouted to a new branch, **When** the operation returns, **Then** the response/notification names both the unavailable previous branch and the new branch.
+
+---
+
+### User Story 2 - Operator can reset the session branch on demand (Priority: P2)
+
+Within a session, an operator decides they want subsequent writes to start on a fresh branch (for example, after an external merge, or to separate a new unit of work) without restarting the server.
+
+**Why this priority**: Provides a deterministic escape hatch so operators are never dependent on automatic detection alone, and gives a clean way to start a new logical change set. Addresses the reported inability to "reset which branch it points at within this session."
+
+**Independent Test**: With an active session branch cached, invoke the reset capability, then issue a write. Verify the write lands on a newly provisioned branch distinct from the previous one.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active cached session branch, **When** the operator resets the session branch, **Then** the next write provisions and targets a new branch.
+2. **Given** no session branch has been created yet, **When** the operator resets the session branch, **Then** the operation succeeds and the next write creates the first branch as normal (reset is idempotent / no-op-safe).
+
+---
+
+### User Story 3 - Operator can point the session at an explicitly named branch (Priority: P3)
+
+An operator wants subsequent writes to target a specific branch by name rather than an auto-generated session branch. They do this by passing a target name to the reset/override tool (US2), which switches the current session to that branch.
+
+**Why this priority**: Closes the reported symptom #2 — attempting to target a different branch failed because the named branch did not yet exist. Lower priority because P1 + P2 already unwedge the common workflow; this adds explicit control.
+
+**Independent Test**: Switch the session to a target branch name that does not yet exist, then issue a write. Verify that — when the name conforms to the configured naming convention — the system creates the branch, points the session at it, and the write lands there, without routing to the stale branch.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing, writable, non-default branch, **When** the operator switches the session to it, **Then** subsequent writes target that branch.
+2. **Given** a non-existent branch name that **conforms** to the configured naming convention (`branch_pattern`), **When** the operator switches the session to it, **Then** the system creates the branch, points the session at it, and explicitly reports that a new branch was created.
+3. **Given** a non-existent branch name that **does not conform** to the configured naming convention, **When** the operator switches the session to it, **Then** the system returns an actionable error and creates nothing.
+4. **Given** the instance default branch, **When** the operator attempts to switch the session to it or write to it, **Then** the request is rejected with the existing default-branch protection message.
+
+---
+
+### Edge Cases
+
+- **Merged vs deleted vs read-only**: All three "cannot accept writes" conditions must trigger the same recovery, regardless of the underlying reason.
+- **Fixed-name branch pattern**: When the configured branch pattern has no placeholders, recreating after a merge would collide with the still-existing (read-only) merged branch. The system must surface a clear, actionable error in this case rather than loop or fail opaquely.
+- **Concurrent writes (same session)**: Two writes arriving while a session's cached branch is stale must converge on a single new branch (no duplicate branches, no race), consistent with the existing locking around session-branch resolution.
+- **Merge during the write window (TOCTOU)**: A branch can be merged between validation and the actual write. The write will fail read-only; the system must clear the cached branch and surface a retryable error rather than stay wedged (FR-011).
+- **Per-session isolation**: The session branch is tracked per MCP session/connection. A reset or recovery in one session must not change, clear, or invalidate the branch another concurrent session is using. (This changes today's process-wide caching.)
+- **Session identity / transport**: Session-branch state keys off the MCP session/connection identity. Transports or requests without a distinct session identity (e.g. a single stdio session, or stateless requests) must still behave correctly — never falling back to one branch shared across unrelated callers.
+- **Default branch unwritable**: Recovery must never resolve to the instance default branch, even if branch discovery is degraded.
+- **Repeated failure**: If provisioning a fresh branch itself fails, the operator must receive a clear error rather than an infinite retry or a silent fall-back to the stale branch.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST determine whether the cached session branch can accept writes — covering deleted, merged, and otherwise read-only branches — before routing a write to it.
+- **FR-002**: On detecting an unwritable cached session branch, the system MUST clear the cached value, provision a fresh writable branch, and proceed with the requested write, without requiring a server restart.
+- **FR-003**: Recovery MUST apply uniformly to every write entry point (node create/update, node delete, and GraphQL mutations that default to the session branch), so no write path can remain wedged to a stale branch.
+- **FR-004**: When a write is rerouted to a newly provisioned branch, the system MUST emit a clear, non-fatal notification identifying both the previously cached branch and the newly created branch.
+- **FR-005**: The system MUST provide a single write-tagged tool to reset or override the active session branch for the current session. Invoked with no target, it MUST clear the session's cached branch so the next write provisions a fresh one. Invoked with a target branch name, it MUST switch the current session to that branch. Reset MUST be safe (no-op) when no branch is currently cached.
+- **FR-006**: When a write or reset targets an explicitly named, non-default branch that does not exist, the system MUST validate the requested name against the configured branch naming convention (`branch_pattern`). If the name conforms, the system MUST create the branch, use it, and explicitly inform the caller that a new branch was created. If the name does not conform, the system MUST return an actionable error and MUST NOT create the branch or silently reroute the write to the cached session branch.
+- **FR-007**: The system MUST continue to reject writes targeting the instance default branch (existing protection preserved).
+- **FR-008**: Recovery and reset MUST be safe under concurrent writes within the same session — at most one new branch is provisioned per recovery event, with no duplicate branches.
+- **FR-009**: The change MUST be covered by automated tests for: merged/read-only recovery (new), deleted-branch recovery (regression), explicit reset, explicit named-branch targeting incl. the not-yet-existing case (both conformant → created and non-conformant → error), and per-session isolation.
+- **FR-010**: The active session branch MUST be scoped to each MCP session/connection rather than shared across the whole server process. Recovery and reset MUST affect only the calling session and MUST NOT change or invalidate the branch in use by other concurrent sessions. Per-session state MUST be released when the session ends (no unbounded growth over the server's lifetime).
+- **FR-011**: If a write fails because the session branch became read-only/merged *after* validation (a merge during the write window), the system MUST clear the session's cached branch and return an actionable error directing the caller to retry; the retry MUST provision a fresh branch. The session MUST NOT remain wedged on the dead branch, and the system MUST NOT blindly replay an arbitrary mutation.
+
+> **Write-authorization hardening (added after review — see [ADR 0007](../../../dev/adr/0007-per-session-branch-recovery-and-reset.md)).**
+
+- **FR-012**: Writes MUST be confined to the active session branch. `mutate_graphql` MUST NOT accept a per-call branch override (like `node_upsert`/`node_delete`, it always targets the session branch); changing which branch a session uses is only possible via the reset/override tool, which continues to reject the default branch.
+- **FR-013**: `mutate_graphql` MUST reject branch-management mutations (`BranchCreate`/`Delete`/`Merge`/`Rebase`/`Update`/`Validate`) and schema mutations, which operate independently of the target branch and would bypass session isolation and the `propose_changes` review gate. When the reset/override tool targets an existing branch, it MUST verify the resolved branch's `is_default` flag (not merely compare names) before allowing it.
+
+### Key Entities *(include if feature involves data)*
+
+- **Session branch**: The write branch tracked **per MCP session/connection** and reused for that session's writes. Has a name, a writability state (writable, read-only/merged, missing), and is provisioned from the configured naming pattern (`branch_pattern`).
+- **Branch writability state**: The classification that drives recovery — distinguishing "usable for writes" from "must be replaced" (deleted, merged, or read-only).
+- **Default branch**: The instance's protected branch (typically `main`) that writes must never target directly.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After the session branch has been merged or deleted, the very next write succeeds on a fresh branch with **0** manual steps and **0** server restarts.
+- **SC-002**: **100%** of **session-branch-routed** write entry points (node create/update, node delete, and `mutate_graphql` without an explicit `branch`) recover from a stale session branch — none remain wedged after the branch becomes unwritable. (Writes that pass an explicit `branch` are outside this guarantee; see FR-006.)
+- **SC-003**: An operator can reset the active session branch in a **single** action and confirm the next write targets a different branch.
+- **SC-004**: The automated test suite includes passing scenarios for merged, deleted, and read-only stale branches, plus explicit reset and explicit named-branch targeting; all pass in CI.
+- **SC-005**: Whenever a write is rerouted to a new branch, the operator receives a message naming both the old and new branch in the same response — no silent branch switch occurs.
+- **SC-006**: A reset or recovery in one MCP session has **0** effect on the branch any other concurrent session is using (verified by an isolation test).
+
+## Assumptions
+
+- The session branch is scoped **per MCP session/connection** (a change from today's process-wide caching). Recovery and reset are isolated to the calling session. Identifying the session/connection and the fallback for transports without a distinct session identity are implementation concerns deferred to planning.
+- In Infrahub, merging a branch leaves it **present but read-only** (it is not auto-deleted); therefore presence checks alone are insufficient to judge usability — writability must be assessed.
+- Reset/override is exposed as a **single write-tagged tool** with an optional target branch (resolved in clarifications), reusing the existing branch-provisioning and default-branch-protection logic.
+- The detection mechanism (proactively classifying writability before the write vs. catching the read-only error returned by the write and then recovering) is an implementation decision deferred to planning; either satisfies FR-001/FR-002 as long as the observable behavior — a successful write on a fresh branch without restart — holds.
+- Existing default-branch write protection and the existing locking around session-branch resolution remain in force and are reused rather than replaced.
+- Audit/logging conventions already present in the write path are reused for the new notifications.

--- a/specs/archive/20260604-141223-session-branch-recovery/tasks.md
+++ b/specs/archive/20260604-141223-session-branch-recovery/tasks.md
@@ -1,0 +1,191 @@
+---
+description: "Task list for Session Branch Recovery & Reset"
+---
+
+# Tasks: Session Branch Recovery & Reset
+
+**Input**: Design documents from `specs/20260604-141223-session-branch-recovery/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/mcp-tools.md
+**Tests**: INCLUDED — required by FR-009 / SC-004 and explicitly requested. TDD per Constitution V (write tests first, see them fail).
+**Branch**: `feat/session-branch-recovery`
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (Setup, Foundational, Polish carry no story label)
+
+## Path Conventions
+
+Single project: `src/infrahub_mcp/`, `tests/unit/` at repo root.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [x] T001 Verify baseline before changes: `uv sync` then `uv run pytest tests/unit/test_session_branch_validation.py` is green (repo root).
+- [x] T002 [P] Create test module skeleton `tests/unit/test_reset_session_branch.py` — imports, pytest-asyncio, and a `_make_ctx(app_ctx, session=None)` helper whose `ctx.request_context.session` returns a stable per-session object (so `WeakKeyDictionary` keying works in tests).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**⚠️ CRITICAL**: every user story touches session-branch state — this phase must complete first. Includes the breaking `AppContext` change (critique E3).
+
+- [x] T003 Refactor `AppContext` in `src/infrahub_mcp/utils.py`: remove `session_branch` and `_session_branch_lock`; add `import weakref`; add `_session_branches: WeakKeyDictionary[Any, str]`, `_session_locks: WeakKeyDictionary[Any, asyncio.Lock]`, and `_session_locks_guard: asyncio.Lock` (keep `default_branch`/`_default_branch_lock` unchanged).
+- [x] T004 Add helpers in `src/infrahub_mcp/utils.py`: `_session_obj(ctx)` (returns `ctx.request_context.session`, raising the existing error when absent), async `_get_session_lock(app_ctx, sess)` (lazy per-session lock created under `_session_locks_guard`), and `get_session_branch(ctx)` (no-create reader: `app_ctx._session_branches.get(_session_obj(ctx))`). Depends on T003.
+- [x] T005 Migrate readers off the removed field: `get_session_info` in `src/infrahub_mcp/tools/session.py` and `propose_changes` in `src/infrahub_mcp/tools/write.py` (lines ~275–306) to read via `get_session_branch(ctx)`; update the `get_session_info` docstring to per-session wording. Depends on T004.
+- [x] T006 Update existing tests in `tests/unit/test_session_branch_validation.py` to the new state model: seed/inspect state via `_session_branches[session]` and the new helpers instead of the `session_branch=` kwarg, preserving the deleted-branch recovery, cached-reuse, and first-write assertions (regression). Depends on T004.
+
+**Checkpoint**: state model compiles, suite runs, deleted-branch recovery still passes.
+
+---
+
+## Phase 3: User Story 1 - Auto-recover after merge/read-only (Priority: P1) 🎯 MVP
+
+**Goal**: Writes succeed on a fresh branch after the session branch is merged/deleting, without a server restart; the swap is reported (old→new). Closes symptoms #1 and #3 and the TOCTOU window (FR-011).
+
+**Independent Test**: Cache a branch whose `branch.get()` returns `status=MERGED`; issue a write; assert it succeeds on a new branch and the old/new names are logged — no restart.
+
+### Tests for User Story 1 (write first, see fail)
+
+- [x] T007 [P] [US1] Parametrized recovery tests in `tests/unit/test_session_branch_validation.py`: cached branch with `status` MERGED and DELETING → entry cleared, new branch created, `ctx.warning` names old + new.
+- [x] T008 [P] [US1] Reuse tests in `tests/unit/test_session_branch_validation.py`: `status` OPEN and NEED_REBASE → cached branch reused, `branch.create` not called.
+- [x] T009 [P] [US1] Per-session isolation test in `tests/unit/test_session_branch_validation.py`: recovery for session A leaves session B's `_session_branches` entry unchanged (two distinct session objects).
+- [x] T010 [P] [US1] FR-011 reactive-net tests in `tests/unit/test_reset_session_branch.py`: a write raising a read-only/`has been merged` `GraphQLError` clears the session entry and raises a retryable `ToolError`; parametrize node_upsert / node_delete / mutate_graphql.
+
+### Implementation for User Story 1
+
+- [x] T011 [US1] In `src/infrahub_mcp/utils.py`: import `BranchStatus` from `infrahub_sdk.branch` and define `_UNWRITABLE_STATUSES = {BranchStatus.MERGED, BranchStatus.DELETING}`.
+- [x] T012 [US1] Extend `get_or_create_session_branch` in `src/infrahub_mcp/utils.py`: key by `_session_obj` + per-session lock; on a cached entry, inspect `branch.get().status` and recover (clear entry, recreate, `ctx.warning` old→new) for `_UNWRITABLE_STATUSES`, in addition to the existing `BranchNotFoundError` path. Depends on T011.
+- [x] T013 [US1] Implement the FR-011 reactive net in `src/infrahub_mcp/tools/write.py`: a small helper that catches read-only/merged `GraphQLError` from SDK writes, clears the calling session's entry, and raises a retryable `ToolError`; apply it in `node_upsert`, `node_delete`, and `mutate_graphql` (default-branch path). Depends on T012.
+
+**Checkpoint**: US1 fully functional — the customer's reported bug is fixed.
+
+---
+
+## Phase 4: User Story 2 - Manual reset of the session branch (Priority: P2)
+
+**Goal**: An operator can drop the session's branch so the next write provisions a fresh one.
+
+**Independent Test**: With a cached branch, call `reset_session_branch()`; assert the entry is cleared and the next `get_or_create_session_branch` creates a new branch.
+
+### Tests for User Story 2
+
+- [x] T014 [P] [US2] Tests in `tests/unit/test_reset_session_branch.py`: `reset_session_branch()` (no arg) clears the entry and returns `action="reset"`, `session_branch=null`; calling it with nothing cached is a safe no-op.
+- [x] T015 [P] [US2] Reset-isolation test in `tests/unit/test_reset_session_branch.py`: reset in session A does not affect session B's entry.
+
+### Implementation for User Story 2
+
+- [x] T016 [US2] Implement `reset_session_branch(ctx, branch: str | None = None)` in `src/infrahub_mcp/tools/write.py`, tagged `{"session", "write"}`, `ToolAnnotations(readOnlyHint=False, idempotentHint=False, destructiveHint=False)`; implement the `branch=None` path (clear this session's entry) and return the documented dict. Mounted via `write_mcp` (auto-hidden in read-only mode).
+- [x] T017 [US2] Update the write-mode system prompt in `src/infrahub_mcp/server.py` (`infrahub_agent`) to document `reset_session_branch` and when to use it (reset vs. switch vs. create).
+
+**Checkpoint**: US1 + US2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - Switch/override to an explicitly named branch (Priority: P3)
+
+**Goal**: Point the session at a named branch; create it when the name conforms to `branch_pattern`, else an actionable error. Closes symptom #2.
+
+**Independent Test**: `reset_session_branch(branch="<conformant-missing-name>")` creates and switches; a non-conformant name errors and creates nothing; `main` is rejected.
+
+### Tests for User Story 3
+
+- [x] T018 [P] [US3] Parametrized `branch_name_conforms` tests in `tests/unit/test_session_branch_validation.py` (or a new `tests/unit/test_branch_conformance.py`): conformant vs non-conformant names, adjacent-placeholder cases, `{user}`-with-`/`, and fixed-pattern exact match.
+- [x] T019 [P] [US3] Tool tests in `tests/unit/test_reset_session_branch.py`: switch to existing writable non-default branch (`action="switched"`); missing + conformant → created + `created=true`; missing + non-conformant → `ToolError`, nothing created; default branch → reject; existing merged/read-only target → `ToolError`.
+
+### Implementation for User Story 3
+
+- [x] T020 [US3] Implement `branch_name_conforms(name, pattern)` in `src/infrahub_mcp/utils.py`: regex via `string.Formatter().parse(pattern)` + `re.escape` literals + non-greedy placeholder classes (`{date}=\d{8}`, `{hex}=[0-9a-f]{8}`, `{user}=[A-Za-z0-9._/-]+?`), anchored; fixed pattern → exact match; plus allowed-charset check (reuse `auth` rules).
+- [x] T021 [US3] Extend `reset_session_branch` in `src/infrahub_mcp/tools/write.py` to handle a provided `branch`: `assert_writable_branch` (reject default); `branch.get()` → exists+writable → switch (`action="switched"`); `BranchNotFoundError` + conformant → create + switch + inform (`action="created"`); not conformant → `ToolError`; `status ∈ _UNWRITABLE_STATUSES` → `ToolError`. Depends on T016, T020.
+
+**Checkpoint**: all three user stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [x] T022 [P] Add user documentation in `docs/docs/` covering auto-recovery and `reset_session_branch` (reset/switch/create + the conformance rule and branch-sprawl note, critique P4); run `uv run rumdl check docs/docs/`.
+- [x] T023 [P] Update `dev/knowledge/` (architecture): per-session branch scoping via `WeakKeyDictionary` + proactive `status` detection + FR-011 reactive net.
+- [x] T024 [P] Add a `dev/adr/` entry recording the decisions: per-session scoping (vs process-wide), proactive `BranchData.status` detection, and the required reactive net.
+- [x] T025 Verify recovery/switch events are captured by the audit trail (critique P5) — confirm the audit middleware in `src/infrahub_mcp/middleware.py` records old→new branch swaps, not just a transient `ctx.warning`; extend if needed.
+- [x] T026 Run full quality gates from repo root: `uv run invoke format lint` (ruff, mypy, pylint, yamllint) and `uv run pytest`; resolve all findings (mypy-clean, no `Any` at public interfaces).
+- [x] T027 Verify live behavior against a running Infrahub. Done as a repeatable, skip-guarded integration suite `tests/integration/test_live_session_branch.py` (drives the tools via FastMCP's in-memory Client + raw SDK for merge/delete setup): merged-branch recovery (the customer bug, end-to-end), deleted-branch recovery, reset/switch/create + reject-default, and privileged-mutation block. All 4 pass against Infrahub 1.9.6; instance left clean (no residue); skipped without INFRAHUB_ADDRESS.
+
+---
+
+## Phase 7: Write-Authorization Hardening (added after code-review; FR-012 / FR-013)
+
+**Goal**: Confine writes to the session branch and close the default-branch escape via `mutate_graphql`.
+
+- [x] T028 Pin `mutate_graphql` to the session branch in `src/infrahub_mcp/tools/write.py`: remove the per-call `branch` parameter and the explicit-branch path; always resolve via `get_or_create_session_branch`; reactive net always applies. Drop now-unused `assert_writable_branch`/`get_default_branch` imports.
+- [x] T029 Add `_assert_no_privileged_mutations` in `src/infrahub_mcp/tools/write.py`: parse the query AST and reject branch-management (`Branch*`) and schema (`SchemaDropdown*`/`SchemaEnum*`) mutations; call it at the top of `mutate_graphql`.
+- [x] T030 Harden the explicit-branch path in `reset_or_switch_session_branch` (`src/infrahub_mcp/utils.py`): reject a resolved branch whose `is_default` is true (not just a name compare).
+- [x] T031 Tests in `tests/unit/test_reset_session_branch.py`: privileged-mutation guard (blocked Branch*/Schema*, allowed node mutation, invalid syntax), `is_default` rejection; update existing switch/merged mocks to set `is_default`. Docs: `methods.mdx` (mutate_graphql param removal + block note), ADR 0007 hardening section, spec FR-012/FR-013.
+
+**Checkpoint**: writes cannot escape the session branch; `BranchMerge`/schema mutations rejected; review gate cannot be bypassed.
+
+---
+
+## Phase 8: Code-Review Fixes (multi-agent review, 43 verified findings)
+
+- [x] T032 Fix CONFIRMED-high findings: (a) `_maybe_recover_read_only` now confirms branch status via `client.branch.get()` before clearing — no false-positive orphaning on read-only *attribute* errors (new `recover_if_session_branch_stale`, clears under the session lock); (b) `_assert_no_privileged_mutations` scans field names recursively (inline fragments / fragment definitions) and rejects non-mutation operations, closing the `... on Mutation { BranchMerge }` bypass. Plus MED: `{user}` regex no longer spans `/` separators; `branch.create` in reset is guarded; removed dead `clear_session_branch`. New regression tests for each; docs/ADR updated.
+
+**Checkpoint**: review findings resolved; full suite green (369 passed).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase order
+
+- **Setup (P1)** → **Foundational (P2, BLOCKS all stories)** → **US1 → US2 → US3** (priority order) → **Polish (P6)**.
+- Decision: built as one whole deliverable (per the "keep it whole" choice), but stories remain independently testable at each checkpoint.
+
+### Cross-task dependencies
+
+- T004 → T003; T005 → T004; T006 → T004.
+- T012 → T011; T013 → T012.
+- T016 → T004; T021 → T016 + T020.
+- All US tests (T007–T010, T014–T015, T018–T019) depend only on the Foundational phase + their helper module.
+- Polish T026 depends on all implementation tasks; T025 depends on T012/T013/T016/T021.
+
+### Within each story
+
+- Tests (Tnnn) written first and failing → then implementation → checkpoint.
+
+## Parallel Opportunities
+
+- **Setup**: T002 ‖ (T001 first).
+- **US1 tests**: T007 ‖ T008 ‖ T009 ‖ T010 (T007–T009 share one file — coordinate or write as one PR commit; T010 is a different file → safe [P]).
+- **US2 tests**: T014 ‖ T015. **US3 tests**: T018 ‖ T019.
+- **Polish docs**: T022 ‖ T023 ‖ T024 (different files).
+
+## Parallel Example: User Story 1
+
+```bash
+# After Foundational completes, write US1 tests together (then watch them fail):
+Task: "Recovery tests (MERGED/DELETING) in tests/unit/test_session_branch_validation.py"   # T007
+Task: "Reuse tests (OPEN/NEED_REBASE) in tests/unit/test_session_branch_validation.py"      # T008
+Task: "Per-session isolation test in tests/unit/test_session_branch_validation.py"          # T009
+Task: "FR-011 reactive-net tests in tests/unit/test_reset_session_branch.py"                # T010
+```
+
+## Implementation Strategy
+
+### MVP (User Story 1)
+
+1. Setup + Foundational.
+2. US1 (auto-recovery + FR-011). **STOP & VALIDATE** — this alone fixes the customer's reported bug (the merged-branch wedge).
+
+### Incremental delivery
+
+US1 (MVP) → US2 (manual reset) → US3 (named-branch switch/create) → Polish. Each checkpoint is independently testable; later stories don't break earlier ones.
+
+## Notes
+
+- `[P]` = different files, no incomplete dependency. Several US1 test tasks touch the same file — land them as one commit or serialize.
+- TDD: confirm each test fails before implementing.
+- Per Constitution V, tests are atomic + parametrized; imports at top; `pytest-asyncio`.
+- Pre-push (user rule): run linters + a code review before commit/push; never commit to `stable`.
+- Branch-sprawl (critique P4): auto-create-on-conformant is intentional; documented in T022 rather than capped.

--- a/src/infrahub_mcp/server.py
+++ b/src/infrahub_mcp/server.py
@@ -215,11 +215,18 @@ def infrahub_agent() -> str:
 - **`node_delete`** — delete a node by `id` or `hfid`.
 - **`mutate_graphql`** — execute a GraphQL mutation.
 - **`propose_changes`** — open a proposed change from your session branch to `main` for human review.
+- **`reset_session_branch`** — reset or switch your session branch: call with no arguments to start \
+fresh (the next write creates a new branch), or pass a branch name to switch to it (created if it \
+matches the configured pattern).
 
 ## Branch-per-session workflow
 
 All writes are branch-isolated. On your first write, a session branch is
 automatically created. The default branch is never modified directly.
+
+If your session branch is merged or deleted, the next write automatically recovers
+onto a fresh branch — you do not need to restart. Use `reset_session_branch` to
+switch branches deliberately.
 
 When changes are ready: call `propose_changes(title, description)` to open a proposed change for human review.
 

--- a/src/infrahub_mcp/tools/session.py
+++ b/src/infrahub_mcp/tools/session.py
@@ -6,6 +6,8 @@ from typing import Any
 from fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 
+from infrahub_mcp.utils import get_session_branch
+
 mcp: FastMCP = FastMCP(name="Infrahub Session")
 
 
@@ -28,13 +30,10 @@ async def get_session_info(ctx: Context) -> dict[str, Any]:
     Returns:
         Dict with ``session_branch`` (str or null), ``infrahub_address``, and ``has_session_branch``.
     """
-    if ctx.request_context is None:
-        msg = "request_context must not be None"
-        raise RuntimeError(msg)
-    app_ctx = ctx.request_context.lifespan_context
     await ctx.debug("Returning session info")
+    session_branch = get_session_branch(ctx)
     return {
-        "session_branch": app_ctx.session_branch,
-        "has_session_branch": app_ctx.session_branch is not None,
+        "session_branch": session_branch,
+        "has_session_branch": session_branch is not None,
         "infrahub_address": os.environ.get("INFRAHUB_ADDRESS", "unknown"),
     }

--- a/src/infrahub_mcp/tools/write.py
+++ b/src/infrahub_mcp/tools/write.py
@@ -1,20 +1,26 @@
 """Write tools for the Infrahub MCP server."""
 
 import logging
+from collections.abc import Iterator
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+from graphql import OperationType
+from graphql import parse as gql_parse
+from graphql.error import GraphQLSyntaxError
 from infrahub_sdk.exceptions import GraphQLError, NodeNotFoundError, SchemaNotFoundError
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
-from infrahub_mcp.auth import assert_writable_branch
 from infrahub_mcp.schema import get_valid_kinds_summary
 from infrahub_mcp.utils import (
     _log_and_raise_error,
     get_client,
-    get_default_branch,
     get_or_create_session_branch,
+    get_session_branch,
+    recover_if_session_branch_stale,
+    reset_or_switch_session_branch,
 )
 
 # pylint: disable=duplicate-code
@@ -23,6 +29,102 @@ logger = logging.getLogger(__name__)
 
 _NO_IDENTIFIER_MSG = "Provide either 'id' (UUID) or 'hfid' (human-friendly ID list) to identify the node."
 _BRANCH_NOTE = "All writes target the active session branch, auto-created on the first write of a session."
+
+_READ_ONLY_MARKERS = ("read-only", "read only", "has been merged")
+
+
+def _is_read_only_error(exc: GraphQLError) -> bool:
+    """Return True if a GraphQL error indicates the target branch is merged/read-only."""
+    text = str(exc).lower()
+    return any(marker in text for marker in _READ_ONLY_MARKERS)
+
+
+async def _maybe_recover_read_only(ctx: Context, exc: GraphQLError) -> None:
+    """Recover from a session branch merged/deleted mid-write (FR-011).
+
+    Only acts when the error *looks* branch-related (cheap pre-filter) **and**
+    Infrahub confirms the session branch is no longer writable: it then clears the
+    cached branch and raises a retryable error so the next write provisions a fresh
+    one. The failed mutation is deliberately not replayed (an arbitrary mutation
+    could partially apply). For any other error — including an unrelated read-only
+    *attribute* error on a perfectly writable branch — it returns so the caller's
+    normal error handling proceeds and the valid session branch is preserved.
+    """
+    if not _is_read_only_error(exc):
+        return
+    detail = await recover_if_session_branch_stale(ctx)
+    if detail is None:
+        return
+    await _log_and_raise_error(
+        ctx=ctx,
+        error=f"Session branch {detail}; it was cleared during the write.",
+        remediation="Retry the operation — a fresh session branch will be created automatically.",
+    )
+
+
+# Infrahub built-in mutations that operate independently of the target branch and
+# would escape session-branch isolation: branch management can merge into / delete the
+# default branch outside the propose_changes review gate; schema mutations alter the
+# instance globally. Names confirmed against infrahub-sdk; update if the SDK adds more.
+_BLOCKED_MUTATIONS = frozenset(
+    {
+        "BranchCreate",
+        "BranchDelete",
+        "BranchMerge",
+        "BranchRebase",
+        "BranchUpdate",
+        "BranchValidate",
+        "SchemaDropdownAdd",
+        "SchemaDropdownRemove",
+        "SchemaEnumAdd",
+        "SchemaEnumRemove",
+    }
+)
+
+
+def _collect_field_names(node: Any) -> Iterator[str]:
+    """Yield every field name reachable from a node's selection set.
+
+    Recurses through inline fragments and nested selections so a privileged field
+    cannot hide inside ``... on Mutation { ... }``. Named fragment definitions are
+    scanned separately as top-level document definitions.
+    """
+    selection_set = getattr(node, "selection_set", None)
+    if selection_set is None:
+        return
+    for selection in selection_set.selections:
+        if getattr(selection, "kind", "") == "field":
+            yield selection.name.value
+        yield from _collect_field_names(selection)
+
+
+def _assert_no_privileged_mutations(query: str) -> None:
+    """Reject non-mutation operations and branch-/schema-management mutations in ``mutate_graphql``.
+
+    Branch/schema mutations bypass session-branch isolation and the human-review
+    gate, so they are not valid session-scoped writes — branch changes go through
+    ``reset_session_branch`` and merges through ``propose_changes``. Field names are
+    inspected recursively (inline fragments, fragment definitions) so a blocked
+    mutation cannot be smuggled in via ``... on Mutation { ... }``.
+    """
+    try:
+        document = gql_parse(query)
+    except GraphQLSyntaxError as exc:
+        msg = f"Invalid GraphQL syntax: {exc}. Fix the mutation and retry; read infrahub://graphql-schema for the SDL."
+        raise ToolError(msg) from exc
+    for definition in document.definitions:
+        operation = getattr(definition, "operation", None)
+        if operation is not None and operation != OperationType.MUTATION:
+            msg = "mutate_graphql only accepts GraphQL mutations; use query_graphql for reads."
+            raise ToolError(msg)
+        for name in _collect_field_names(definition):
+            if name in _BLOCKED_MUTATIONS:
+                msg = (
+                    f"Mutation '{name}' is not allowed via mutate_graphql. Branch and schema "
+                    "management bypass session-branch isolation and the review gate. Use "
+                    "reset_session_branch for branch changes and propose_changes to merge."
+                )
+                raise ToolError(msg)
 
 
 @mcp.tool(
@@ -135,6 +237,7 @@ async def node_upsert(  # pylint: disable=too-many-locals
     except NodeNotFoundError as exc:
         await _log_and_raise_error(ctx=ctx, error=exc, remediation=_NO_IDENTIFIER_MSG)
     except GraphQLError as exc:
+        await _maybe_recover_read_only(ctx, exc)
         await _log_and_raise_error(
             ctx=ctx,
             error=exc,
@@ -221,7 +324,14 @@ async def node_delete(
     except NodeNotFoundError as exc:
         await _log_and_raise_error(ctx=ctx, error=exc, remediation="Verify the id/hfid is correct.")
     except GraphQLError as exc:
-        await _log_and_raise_error(ctx=ctx, error=exc)
+        await _maybe_recover_read_only(ctx, exc)
+        await _log_and_raise_error(
+            ctx=ctx,
+            error=exc,
+            remediation=(
+                f"Verify the node exists and has no relationships blocking deletion; check infrahub://schema/{kind}."
+            ),
+        )
 
     return {"deleted_id": id or hfid, "branch": session_branch}
 
@@ -267,19 +377,13 @@ async def propose_changes(
         Dict with proposed change id and branch details on success.
     """
     client = get_client(ctx)
-    if ctx.request_context is None:
-        msg = "request_context must not be None"
-        raise RuntimeError(msg)
-    app_ctx = ctx.request_context.lifespan_context
-
-    if app_ctx.session_branch is None:
+    session_branch = get_session_branch(ctx)
+    if session_branch is None:
         await _log_and_raise_error(
             ctx=ctx,
             error="No session branch exists yet.",
             remediation="Make at least one write (node_upsert / node_delete) before proposing changes.",
         )
-
-    session_branch: str = app_ctx.session_branch
 
     if destination_branch is None:
         branches = await client.branch.all()
@@ -298,7 +402,11 @@ async def propose_changes(
         )
         await node.save()
     except GraphQLError as exc:
-        await _log_and_raise_error(ctx=ctx, error=exc)
+        await _log_and_raise_error(
+            ctx=ctx,
+            error=exc,
+            remediation="Verify the destination branch exists and your session branch has changes to propose.",
+        )
 
     return {
         "id": node.id,
@@ -314,18 +422,7 @@ async def propose_changes(
 )
 async def mutate_graphql(
     ctx: Context,
-    query: Annotated[str, Field(description="GraphQL mutation to execute.")],
-    branch: Annotated[
-        str | None,
-        Field(
-            default=None,
-            description=(
-                "Branch to execute the mutation against. "
-                "Defaults to the auto-created session branch (recommended). "
-                "Override only when targeting a specific non-default branch."
-            ),
-        ),
-    ] = None,
+    query: Annotated[str, Field(description="GraphQL mutation to execute on the active session branch.")],
 ) -> dict[str, Any]:
     """Execute a GraphQL mutation against Infrahub — use only for complex writes that typed tools can't express.
 
@@ -335,34 +432,31 @@ async def mutate_graphql(
     when you need relationship edits, bulk operations, or any mutation shape
     not covered by the typed tools. For reads, use ``query_graphql``.
 
-    The mutation targets the session branch by default, which is auto-created
-    on the first write of the session (``mcp/session-YYYYMMDD-<hex>``).
+    The mutation always runs on the **active session branch** (auto-created on the
+    first write of the session, ``mcp/session-YYYYMMDD-<hex>``). There is no branch
+    override — writes are isolated to the session, and changes reach the default
+    branch only through ``propose_changes`` and human review. To target a different
+    branch deliberately, switch the session with ``reset_session_branch`` first.
+    Branch- and schema-management mutations are rejected.
 
     To discover available kinds and their attributes, read the ``infrahub://schema``
     resource or call the ``get_schema`` tool.
     For the full GraphQL SDL, read ``infrahub://graphql-schema``.
 
     Parameters:
-        query: GraphQL mutation to execute.
-        branch: Branch to execute against. Defaults to the session branch.
+        query: GraphQL mutation to execute on the session branch.
 
     Returns:
         The result of the mutation.
     """
+    _assert_no_privileged_mutations(query)
     client = get_client(ctx)
-
-    if branch is None:
-        branch = await get_or_create_session_branch(ctx)
-    else:
-        try:
-            default_branch = await get_default_branch(ctx)
-            assert_writable_branch(branch, default_branch=default_branch)
-        except ValueError as exc:
-            await _log_and_raise_error(ctx=ctx, error=str(exc))
+    branch = await get_or_create_session_branch(ctx)
 
     try:
         data = await client.execute_graphql(query=query, branch_name=branch)
     except GraphQLError as exc:
+        await _maybe_recover_read_only(ctx, exc)
         await _log_and_raise_error(
             ctx,
             exc,
@@ -374,3 +468,49 @@ async def mutate_graphql(
         )
 
     return data
+
+
+@mcp.tool(
+    tags={"session", "write"},
+    annotations=ToolAnnotations(readOnlyHint=False, idempotentHint=False, destructiveHint=False),
+)
+async def reset_session_branch(
+    ctx: Context,
+    branch: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Target branch. Omit to drop the cached session branch so the next write "
+                "creates a fresh one. Provide a name to switch this session to that branch "
+                "(created if it does not exist and the name matches the configured pattern)."
+            ),
+        ),
+    ] = None,
+) -> dict[str, Any]:
+    """Reset or switch the active session branch for the current MCP session.
+
+    Use this to recover or take control of which branch your writes target:
+
+    - **No ``branch``** — clears the cached session branch; the next write
+      auto-creates a fresh one. Useful after you have merged your work and want
+      to start a new change set.
+    - **With ``branch``** — points this session at the named branch. If it does
+      not exist and the name matches the configured branch pattern, it is created
+      and reported. The instance default branch and merged/read-only branches are
+      rejected.
+
+    Note: a merged or deleted session branch is recovered **automatically** on the
+    next write — this tool is the explicit override on top of that.
+
+    Affects only the calling session; other sessions are unaffected.
+
+    Parameters:
+        branch: Target branch name, or omit to reset to a fresh auto-created branch.
+
+    Returns:
+        Dict with ``session_branch`` (active branch after the call, or null),
+        ``previous_branch``, ``created`` (bool), and ``action``
+        (``reset`` | ``switched`` | ``created``).
+    """
+    return await reset_or_switch_session_branch(ctx, branch)

--- a/src/infrahub_mcp/utils.py
+++ b/src/infrahub_mcp/utils.py
@@ -1,36 +1,56 @@
 import asyncio
 import os
+import re
 import secrets
+import string
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, NoReturn
+from weakref import WeakKeyDictionary
 
 from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from infrahub_sdk import Config
+from infrahub_sdk.branch import BranchStatus
 from infrahub_sdk.client import InfrahubClient
 from infrahub_sdk.exceptions import BranchNotFoundError, GraphQLError, NodeNotFoundError
 from infrahub_sdk.exceptions import Error as SdkError
 from infrahub_sdk.node import Attribute, InfrahubNode, RelatedNode, RelationshipManager
 
-from infrahub_mcp.auth import get_passthrough_basic, get_passthrough_token, get_user_from_token
+from infrahub_mcp.auth import (
+    assert_writable_branch,
+    get_passthrough_basic,
+    get_passthrough_token,
+    get_user_from_token,
+)
 from infrahub_mcp.config import ServerConfig
 from infrahub_mcp.constants import AUTH_MODE_BASIC_PASSTHROUGH, AUTH_MODE_TOKEN_PASSTHROUGH
 
 CURRENT_DIRECTORY = Path(__file__).parent.resolve()
 
 
+_UNWRITABLE_STATUSES = frozenset({BranchStatus.MERGED, BranchStatus.DELETING})
+
+
 @dataclass
 class AppContext:
-    """Application context held for the lifetime of an MCP connection."""
+    """Application context shared for the lifetime of the MCP server process.
+
+    The active session branch is tracked **per MCP session/connection**, not
+    process-wide: the branch name and its lock are keyed by the per-session
+    object in ``WeakKeyDictionary`` maps. Entries are released automatically when
+    a session ends (no unbounded growth), and a reset/recovery in one session
+    never disturbs another. ``default_branch`` stays instance-wide.
+    """
 
     client: InfrahubClient | None
     config: ServerConfig
-    session_branch: str | None = field(default=None)
     default_branch: str | None = field(default=None)
-    _session_branch_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _default_branch_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _session_branches: WeakKeyDictionary[object, str] = field(default_factory=WeakKeyDictionary)
+    _session_locks: WeakKeyDictionary[object, asyncio.Lock] = field(default_factory=WeakKeyDictionary)
+    _session_locks_guard: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 def get_client(ctx: Context) -> InfrahubClient:
@@ -79,6 +99,68 @@ def get_client(ctx: Context) -> InfrahubClient:
         msg = "No Infrahub client available."
         raise ToolError(msg)
     return app_ctx.client
+
+
+def _session_obj(ctx: Context) -> object:
+    """Return the per-MCP-session object used to scope session-branch state.
+
+    The session object is stable across tool calls within one client session and
+    distinct across sessions, for every transport. Used as the key for the
+    per-session ``WeakKeyDictionary`` maps on ``AppContext`` so state is isolated
+    per session and released when the session ends.
+    """
+    if ctx.request_context is None or getattr(ctx.request_context, "session", None) is None:
+        msg = "request_context.session must not be None"
+        raise RuntimeError(msg)
+    return ctx.request_context.session
+
+
+async def _get_session_lock(app_ctx: AppContext, session: object) -> asyncio.Lock:
+    """Return the per-session branch lock, creating it on first use."""
+    async with app_ctx._session_locks_guard:  # noqa: SLF001
+        lock = app_ctx._session_locks.get(session)  # noqa: SLF001
+        if lock is None:
+            lock = asyncio.Lock()
+            app_ctx._session_locks[session] = lock  # noqa: SLF001
+        return lock
+
+
+def get_session_branch(ctx: Context) -> str | None:
+    """Return the calling session's active branch, or ``None`` if none is set."""
+    if ctx.request_context is None:
+        msg = "request_context must not be None"
+        raise RuntimeError(msg)
+    app_ctx: AppContext = ctx.request_context.lifespan_context
+    return app_ctx._session_branches.get(_session_obj(ctx))  # noqa: SLF001
+
+
+_BRANCH_CHARSET = re.compile(r"[A-Za-z0-9._/-]+")
+# Placeholder classes exclude '/' so a {user}/unknown placeholder can't greedily
+# span the literal path separators of the pattern (e.g. "mcp/{user}/work").
+_PLACEHOLDER_PATTERNS = {
+    "date": r"\d{8}",
+    "hex": r"[0-9a-f]{8}",
+    "user": r"[A-Za-z0-9._-]+?",
+}
+_DEFAULT_PLACEHOLDER_PATTERN = r"[A-Za-z0-9._-]+?"
+
+
+def branch_name_conforms(name: str, pattern: str) -> bool:
+    """Return True if ``name`` matches the configured ``branch_pattern`` convention.
+
+    Literal segments of the pattern must match exactly; placeholders match the
+    shape they generate ({date}=8 digits, {hex}=8 lowercase hex, {user}=branch-safe
+    characters, non-greedy). A pattern with no placeholders requires an exact
+    match. The name must also use only allowed branch characters.
+    """
+    if _BRANCH_CHARSET.fullmatch(name) is None:
+        return False
+    regex_parts: list[str] = []
+    for literal, field_name, _spec, _conv in string.Formatter().parse(pattern):
+        regex_parts.append(re.escape(literal))
+        if field_name:
+            regex_parts.append(_PLACEHOLDER_PATTERNS.get(field_name, _DEFAULT_PLACEHOLDER_PATTERN))
+    return re.fullmatch("".join(regex_parts), name) is not None
 
 
 def _has_placeholders(pattern: str) -> bool:
@@ -131,7 +213,8 @@ async def _create_branch_with_pattern(app_ctx: AppContext, ctx: Context) -> str:
             if not _is_branch_conflict(exc) or attempt == max_retries - 1:
                 msg = (
                     f"Failed to create branch '{branch_name}' after "
-                    f"{attempt + 1} attempt(s) using pattern '{pattern}': {exc}"
+                    f"{attempt + 1} attempt(s) using pattern '{pattern}': {exc}. "
+                    "Retry; if it persists, the Infrahub branch API may be unavailable."
                 )
                 raise ToolError(msg) from exc
             # Collision — retry with a new hex
@@ -157,10 +240,10 @@ async def _create_branch_fixed(app_ctx: AppContext, ctx: Context) -> str:
     except GraphQLError as exc:
         if _is_branch_conflict(exc):
             msg = (
-                f"Branch '{branch_name}' already exists. "
-                "A fixed branch pattern cannot reuse an existing branch. "
-                "Use a pattern with {hex} or {date} placeholders for unique branches, "
-                "or delete the existing branch first."
+                f"Branch '{branch_name}' already exists (it may have been merged and is now "
+                "read-only). A fixed branch pattern cannot recover onto a fresh branch. "
+                "Use a branch pattern with {hex} or {date} placeholders so recovery can create "
+                "a unique branch, or delete the existing branch first."
             )
             raise ToolError(msg) from exc
         raise
@@ -188,42 +271,173 @@ async def get_default_branch(ctx: Context) -> str:
     return app_ctx.default_branch
 
 
-async def get_or_create_session_branch(ctx: Context) -> str:
-    """Return the session branch, auto-creating it on the first write of the session.
+async def _stale_branch_reason(client: InfrahubClient, branch_name: str) -> str | None:
+    """Return why a cached branch can't be reused, or ``None`` if it is writable.
 
-    Uses the branch pattern from ``ServerConfig.branch_pattern``:
+    A single ``branch.get()`` validates the branch against Infrahub:
+    - missing (deleted, merged-then-pruned, dev reset) -> ``BranchNotFoundError``
+    - status MERGED / DELETING -> still present but read-only / being removed
+
+    A merged branch is **not** deleted in Infrahub — it stays present and
+    read-only — so existence alone is insufficient; the status must be checked.
+    """
+    try:
+        branch = await client.branch.get(branch_name=branch_name)
+    except BranchNotFoundError:
+        return "no longer exists on Infrahub"
+    if branch.status in _UNWRITABLE_STATUSES:
+        return f"is read-only (status {branch.status.value})"
+    return None
+
+
+async def _provision_session_branch(app_ctx: AppContext, ctx: Context) -> str:
+    """Create a new session branch using the configured pattern."""
+    if _has_placeholders(app_ctx.config.branch_pattern):
+        return await _create_branch_with_pattern(app_ctx, ctx)
+    return await _create_branch_fixed(app_ctx, ctx)
+
+
+async def get_or_create_session_branch(ctx: Context) -> str:
+    """Return this session's branch, auto-creating it on the first write of the session.
+
+    Scoped per MCP session (keyed by the session object). Uses the branch pattern
+    from ``ServerConfig.branch_pattern``:
     - Patterns with placeholders ({date}, {hex}, {user}) are expanded.
       If creation fails due to a name conflict, a new {hex} is generated (up to max retries).
-    - Fixed names (no placeholders) attempt a single creation — if the branch
-      already exists the server raises a clear error.
+    - Fixed names (no placeholders) attempt a single creation.
 
-    The cached branch name is validated against Infrahub before reuse — if it
-    has been deleted (merged proposed change, manual delete, dev server reset)
-    the cache is cleared and a new branch is created. Without this check the
-    cache is process-scoped and a stale name would persist across MCP sessions
-    until the server process restarts.
+    The cached branch is validated against Infrahub before reuse. If it has been
+    deleted **or merged (now read-only)**, the cache is cleared and a fresh branch
+    is provisioned automatically — the caller is warned, naming both the old and
+    new branch — so writes recover without a server restart.
     """
     if ctx.request_context is None:
         msg = "request_context must not be None"
         raise RuntimeError(msg)
     app_ctx: AppContext = ctx.request_context.lifespan_context
-    async with app_ctx._session_branch_lock:  # noqa: SLF001
-        if app_ctx.session_branch is not None:
-            client = get_client(ctx)
-            try:
-                await client.branch.get(branch_name=app_ctx.session_branch)
-            except BranchNotFoundError:
+    session = _session_obj(ctx)
+    lock = await _get_session_lock(app_ctx, session)
+    async with lock:
+        current = app_ctx._session_branches.get(session)  # noqa: SLF001
+        stale_reason: str | None = None
+        if current is not None:
+            stale_reason = await _stale_branch_reason(get_client(ctx), current)
+            if stale_reason is not None:
+                app_ctx._session_branches.pop(session, None)  # noqa: SLF001
+        if current is None or stale_reason is not None:
+            created = await _provision_session_branch(app_ctx, ctx)
+            app_ctx._session_branches[session] = created  # noqa: SLF001
+            if stale_reason is not None:
                 await ctx.warning(
-                    f"Cached session branch {app_ctx.session_branch!r} no longer exists on "
-                    "Infrahub; creating a new one."
+                    f"Session branch {current!r} {stale_reason}; recovered onto a new branch {created!r}."
                 )
-                app_ctx.session_branch = None
-        if app_ctx.session_branch is None:
-            if _has_placeholders(app_ctx.config.branch_pattern):
-                app_ctx.session_branch = await _create_branch_with_pattern(app_ctx, ctx)
-            else:
-                app_ctx.session_branch = await _create_branch_fixed(app_ctx, ctx)
-    return app_ctx.session_branch
+            return created
+        return current
+
+
+async def recover_if_session_branch_stale(ctx: Context) -> str | None:
+    """Clear the calling session's branch if it is no longer writable; return the reason.
+
+    Used by the write paths (FR-011) to recover from a branch merged/deleted *during*
+    a write. The branch status is confirmed against Infrahub before anything is
+    cleared — the write error text alone is ambiguous (a read-only *attribute* error
+    also contains "read-only"). Returns ``"<branch> <reason>"`` when the cached branch
+    was stale and has now been cleared, or ``None`` when it is still writable.
+    """
+    if ctx.request_context is None:
+        msg = "request_context must not be None"
+        raise RuntimeError(msg)
+    app_ctx: AppContext = ctx.request_context.lifespan_context
+    session = _session_obj(ctx)
+    lock = await _get_session_lock(app_ctx, session)
+    async with lock:
+        branch = app_ctx._session_branches.get(session)  # noqa: SLF001
+        if branch is None:
+            return None
+        reason = await _stale_branch_reason(get_client(ctx), branch)
+        if reason is None:
+            return None
+        app_ctx._session_branches.pop(session, None)  # noqa: SLF001
+        return f"{branch!r} {reason}"
+
+
+async def reset_or_switch_session_branch(ctx: Context, branch: str | None) -> dict[str, Any]:
+    """Reset or switch the calling session's branch (backs the ``reset_session_branch`` tool).
+
+    - ``branch is None``: clear the cached branch so the next write provisions a fresh one.
+    - ``branch`` given: point this session at it. Rejects the default branch and
+      read-only/merged branches. If the branch does not exist and the name conforms
+      to ``branch_pattern``, it is created; otherwise an actionable error is raised.
+
+    Affects only the calling session.
+    """
+    if ctx.request_context is None:
+        msg = "request_context must not be None"
+        raise RuntimeError(msg)
+    app_ctx: AppContext = ctx.request_context.lifespan_context
+    session = _session_obj(ctx)
+    lock = await _get_session_lock(app_ctx, session)
+    async with lock:
+        previous = app_ctx._session_branches.get(session)  # noqa: SLF001
+
+        if branch is None:
+            app_ctx._session_branches.pop(session, None)  # noqa: SLF001
+            await ctx.info(f"Session branch reset (was {previous!r}); next write will create a new one.")
+            return {"session_branch": None, "previous_branch": previous, "created": False, "action": "reset"}
+
+        default_branch = await get_default_branch(ctx)
+        try:
+            assert_writable_branch(branch, default_branch=default_branch)
+        except ValueError as exc:
+            await _log_and_raise_error(ctx=ctx, error=str(exc))
+
+        client = get_client(ctx)
+        created = False
+        try:
+            existing = await client.branch.get(branch_name=branch)
+        except BranchNotFoundError:
+            if not branch_name_conforms(branch, app_ctx.config.branch_pattern):
+                await _log_and_raise_error(
+                    ctx=ctx,
+                    error=f"Branch {branch!r} does not exist and does not match the configured "
+                    f"branch pattern {app_ctx.config.branch_pattern!r}.",
+                    remediation="Use a name that matches the pattern, or omit 'branch' to "
+                    "auto-create a session branch.",
+                )
+            await ctx.info(f"Creating branch {branch!r} (matches the configured pattern).")
+            try:
+                await client.branch.create(branch_name=branch, sync_with_git=False, wait_until_completion=True)
+            except GraphQLError as exc:
+                await _log_and_raise_error(
+                    ctx=ctx,
+                    error=f"Failed to create branch {branch!r}: {exc}",
+                    remediation="Choose a different name, or omit 'branch' to auto-create a session branch.",
+                )
+            created = True
+        else:
+            # Resolve is_default on the actual branch — robust against case/alias
+            # variants that a name-only compare in assert_writable_branch would miss.
+            if existing.is_default:
+                await _log_and_raise_error(
+                    ctx=ctx,
+                    error=f"Branch {branch!r} resolves to the instance default branch; writes to it are not allowed.",
+                    remediation="Use the session branch or a feature branch; merge via propose_changes.",
+                )
+            if existing.status in _UNWRITABLE_STATUSES:
+                await _log_and_raise_error(
+                    ctx=ctx,
+                    error=f"Branch {branch!r} is read-only (status {existing.status.value}); "
+                    "cannot target it for writes.",
+                    remediation="Choose a writable branch, or omit 'branch' to create a fresh session branch.",
+                )
+
+        app_ctx._session_branches[session] = branch  # noqa: SLF001
+        return {
+            "session_branch": branch,
+            "previous_branch": previous,
+            "created": created,
+            "action": "created" if created else "switched",
+        }
 
 
 async def _log_and_raise_error(ctx: Context, error: str | Exception, remediation: str | None = None) -> NoReturn:

--- a/tests/integration/test_live_session_branch.py
+++ b/tests/integration/test_live_session_branch.py
@@ -1,0 +1,166 @@
+"""Live integration tests against a running Infrahub.
+
+Reproduces the customer scenario end-to-end through the MCP tools (via FastMCP's
+in-memory ``Client`` — exercising the real tool wiring) and uses the raw SDK for
+setup/teardown the tools intentionally cannot do (merge/delete branches).
+
+Skipped unless ``INFRAHUB_ADDRESS`` is set, so normal unit CI is unaffected:
+
+    INFRAHUB_ADDRESS=http://localhost:8000 \
+    INFRAHUB_API_TOKEN=06438eb2-8019-4776-878c-0941b1f1d1ec \
+    uv run pytest tests/integration/test_live_session_branch.py -q
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import uuid
+from typing import Any
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+from infrahub_sdk import Config, InfrahubClient
+
+from infrahub_mcp.server import mcp
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("INFRAHUB_ADDRESS"),
+    reason="requires a live Infrahub (set INFRAHUB_ADDRESS / INFRAHUB_API_TOKEN)",
+)
+
+ADDR = os.environ.get("INFRAHUB_ADDRESS", "")
+TOKEN = os.environ.get("INFRAHUB_API_TOKEN", "")
+
+
+def _raw() -> InfrahubClient:
+    return InfrahubClient(config=Config(address=ADDR, api_token=TOKEN))
+
+
+def _data(result: Any) -> dict[str, Any]:
+    """Extract the tool's returned dict from a FastMCP CallToolResult."""
+    data = getattr(result, "data", None)
+    if isinstance(data, dict):
+        return data
+    structured = getattr(result, "structured_content", None)
+    if isinstance(structured, dict):
+        return structured
+    import json  # noqa: PLC0415
+
+    return json.loads(result.content[0].text)
+
+
+def _tag() -> str:
+    return f"mcp-live-{uuid.uuid4().hex[:8]}"
+
+
+async def _delete_branch(raw: InfrahubClient, name: str) -> None:
+    with contextlib.suppress(Exception):
+        await raw.branch.delete(branch_name=name)
+
+
+async def _delete_tag(raw: InfrahubClient, name: str, branch: str = "main") -> None:
+    with contextlib.suppress(Exception):
+        node = await raw.get(kind="BuiltinTag", name__value=name, branch=branch)
+        await node.delete()
+
+
+async def test_live_recovers_after_session_branch_merged() -> None:
+    """THE customer bug: merge the session branch, then the next write recovers onto a fresh branch."""
+    raw = _raw()
+    branches: list[str] = []
+    tag1, tag2 = _tag(), _tag()
+    try:
+        async with Client(mcp) as cl:
+            r1 = _data(await cl.call_tool("node_upsert", {"kind": "BuiltinTag", "data": {"name": tag1}}))
+            b1 = r1["branch"]
+            branches.append(b1)
+            assert b1.startswith("mcp/session-")
+
+            # The intended end-of-work step that used to wedge the session.
+            await raw.branch.merge(branch_name=b1)
+
+            # Next write must succeed on a NEW branch — no "merged and is read-only" error, no restart.
+            r2 = _data(await cl.call_tool("node_upsert", {"kind": "BuiltinTag", "data": {"name": tag2}}))
+            b2 = r2["branch"]
+            branches.append(b2)
+            assert b2 != b1, "expected auto-recovery onto a fresh session branch"
+            assert b2.startswith("mcp/session-")
+    finally:
+        for b in branches:
+            await _delete_branch(raw, b)
+        await _delete_tag(raw, tag1)  # tag1 was merged onto main
+
+
+async def test_live_recovers_after_session_branch_deleted() -> None:
+    """Regression: a deleted session branch also recovers."""
+    raw = _raw()
+    branches: list[str] = []
+    try:
+        async with Client(mcp) as cl:
+            b1 = _data(await cl.call_tool("node_upsert", {"kind": "BuiltinTag", "data": {"name": _tag()}}))["branch"]
+            branches.append(b1)
+            await raw.branch.delete(branch_name=b1)
+            b2 = _data(await cl.call_tool("node_upsert", {"kind": "BuiltinTag", "data": {"name": _tag()}}))["branch"]
+            branches.append(b2)
+            assert b2 != b1
+    finally:
+        for b in branches:
+            await _delete_branch(raw, b)
+
+
+async def test_live_reset_switch_create_and_reject_default() -> None:
+    raw = _raw()
+    branches: list[str] = []
+    conformant = f"mcp/session-20990101-{uuid.uuid4().hex[:8]}"
+    try:
+        async with Client(mcp) as cl:
+            b1 = _data(await cl.call_tool("node_upsert", {"kind": "BuiltinTag", "data": {"name": _tag()}}))["branch"]
+            branches.append(b1)
+
+            reset = _data(await cl.call_tool("reset_session_branch", {}))
+            assert reset["action"] == "reset"
+            assert reset["previous_branch"] == b1
+            assert reset["session_branch"] is None
+
+            created = _data(await cl.call_tool("reset_session_branch", {"branch": conformant}))
+            branches.append(conformant)
+            assert created["action"] == "created"
+            assert created["session_branch"] == conformant
+
+            with pytest.raises(ToolError):
+                await cl.call_tool("reset_session_branch", {"branch": "main"})
+    finally:
+        for b in branches:
+            await _delete_branch(raw, b)
+
+
+async def test_live_blocks_privileged_mutations_via_mutate_graphql() -> None:
+    raw = _raw()
+    branches: list[str] = []
+    tag = _tag()
+    try:
+        async with Client(mcp) as cl:
+            with pytest.raises(ToolError):
+                await cl.call_tool("mutate_graphql", {"query": 'mutation { BranchMerge(data: {name: "main"}) { ok } }'})
+            # inline-fragment smuggling is also blocked
+            with pytest.raises(ToolError):
+                await cl.call_tool(
+                    "mutate_graphql",
+                    {"query": 'mutation { ... on Mutation { BranchMerge(data: {name: "main"}) { ok } } }'},
+                )
+            # a normal data mutation still works (and opens a session branch)
+            res = _data(
+                await cl.call_tool(
+                    "mutate_graphql",
+                    {"query": f'mutation {{ BuiltinTagCreate(data: {{name: {{value: "{tag}"}}}}) {{ ok }} }}'},
+                )
+            )
+            assert res.get("BuiltinTagCreate", {}).get("ok") is True
+            info = _data(await cl.call_tool("get_session_info", {}))
+            branches.append(info["session_branch"])
+            assert info["has_session_branch"] is True
+    finally:
+        for b in branches:
+            await _delete_branch(raw, b)

--- a/tests/unit/test_reset_session_branch.py
+++ b/tests/unit/test_reset_session_branch.py
@@ -33,9 +33,9 @@ def _make_ctx(app_ctx: AppContext) -> MagicMock:
     return ctx
 
 
-def _app_ctx(**kwargs: object) -> AppContext:
+def _app_ctx() -> AppContext:
     config = ServerConfig(auth_mode="none", branch_pattern=_PATTERN)
-    return AppContext(client=MagicMock(), config=config, default_branch="main", **kwargs)  # type: ignore[arg-type]
+    return AppContext(client=MagicMock(), config=config, default_branch="main")
 
 
 class TestResetSessionBranch:

--- a/tests/unit/test_reset_session_branch.py
+++ b/tests/unit/test_reset_session_branch.py
@@ -1,0 +1,247 @@
+"""Tests for the reset/switch session-branch capability and the read-only write recovery net.
+
+Covers ``reset_or_switch_session_branch`` (backing the ``reset_session_branch`` tool):
+no-arg reset, switch to an existing branch, create-on-conformant, error-on-nonconformant,
+default-branch rejection, merged-target rejection, and per-session isolation. Also covers
+``_maybe_recover_read_only`` (FR-011): a write that fails because the branch was merged
+mid-write clears the session entry and raises a retryable error.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+from infrahub_sdk.branch import BranchStatus
+from infrahub_sdk.exceptions import BranchNotFoundError, GraphQLError
+
+from infrahub_mcp.config import ServerConfig
+from infrahub_mcp.tools.write import _assert_no_privileged_mutations, _maybe_recover_read_only
+from infrahub_mcp.utils import AppContext, reset_or_switch_session_branch
+
+_PATTERN = "mcp/session-{date}-{hex}"
+
+
+def _make_ctx(app_ctx: AppContext) -> MagicMock:
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context = app_ctx
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    ctx.debug = AsyncMock()
+    ctx.error = AsyncMock()
+    return ctx
+
+
+def _app_ctx(**kwargs: object) -> AppContext:
+    config = ServerConfig(auth_mode="none", branch_pattern=_PATTERN)
+    return AppContext(client=MagicMock(), config=config, default_branch="main", **kwargs)  # type: ignore[arg-type]
+
+
+class TestResetSessionBranch:
+    async def test_reset_no_arg_clears_entry(self) -> None:
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+        app_ctx._session_branches[ctx.request_context.session] = "mcp/session-x"  # noqa: SLF001
+
+        result = await reset_or_switch_session_branch(ctx, None)
+
+        assert result["action"] == "reset"
+        assert result["session_branch"] is None
+        assert result["previous_branch"] == "mcp/session-x"
+        assert ctx.request_context.session not in app_ctx._session_branches  # noqa: SLF001
+
+    async def test_reset_no_arg_safe_when_empty(self) -> None:
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+
+        result = await reset_or_switch_session_branch(ctx, None)
+
+        assert result["action"] == "reset"
+        assert result["previous_branch"] is None
+
+    async def test_switch_to_existing_writable(self) -> None:
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+        client = MagicMock()
+        existing = MagicMock()
+        existing.status = BranchStatus.OPEN
+        existing.is_default = False
+        client.branch.get = AsyncMock(return_value=existing)
+        client.branch.create = AsyncMock()
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            result = await reset_or_switch_session_branch(ctx, "mcp/session-existing")
+
+        assert result["action"] == "switched"
+        assert result["created"] is False
+        assert result["session_branch"] == "mcp/session-existing"
+        assert app_ctx._session_branches[ctx.request_context.session] == "mcp/session-existing"  # noqa: SLF001
+        client.branch.create.assert_not_called()
+
+    async def test_create_on_conformant_missing(self) -> None:
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+        client = MagicMock()
+        client.branch.get = AsyncMock(side_effect=BranchNotFoundError(identifier="x"))
+        client.branch.create = AsyncMock()
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            result = await reset_or_switch_session_branch(ctx, "mcp/session-20260101-deadbeef")
+
+        assert result["action"] == "created"
+        assert result["created"] is True
+        assert result["session_branch"] == "mcp/session-20260101-deadbeef"
+        client.branch.create.assert_called_once()
+
+    async def test_error_on_nonconformant_missing(self) -> None:
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+        client = MagicMock()
+        client.branch.get = AsyncMock(side_effect=BranchNotFoundError(identifier="x"))
+        client.branch.create = AsyncMock()
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client), pytest.raises(ToolError, match="omit"):
+            await reset_or_switch_session_branch(ctx, "totally-random-name")
+
+        client.branch.create.assert_not_called()
+
+    async def test_reject_default_branch(self) -> None:
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+        client = MagicMock()
+
+        with (
+            patch("infrahub_mcp.utils.get_client", return_value=client),
+            pytest.raises(ToolError, match="propose_changes"),
+        ):
+            await reset_or_switch_session_branch(ctx, "main")
+
+    async def test_reject_merged_target(self) -> None:
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+        client = MagicMock()
+        merged = MagicMock()
+        merged.status = BranchStatus.MERGED
+        merged.is_default = False
+        client.branch.get = AsyncMock(return_value=merged)
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client), pytest.raises(ToolError):
+            await reset_or_switch_session_branch(ctx, "mcp/session-merged")
+
+    async def test_reject_branch_resolving_to_default(self) -> None:
+        """A target whose resolved branch is is_default is rejected even if the name differs."""
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+        client = MagicMock()
+        resolved_default = MagicMock()
+        resolved_default.status = BranchStatus.OPEN
+        resolved_default.is_default = True
+        client.branch.get = AsyncMock(return_value=resolved_default)
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client), pytest.raises(ToolError):
+            await reset_or_switch_session_branch(ctx, "mcp/session-aliasmain")
+
+    async def test_switch_isolated_per_session(self) -> None:
+        app_ctx = _app_ctx()
+        ctx_a = _make_ctx(app_ctx)
+        ctx_b = _make_ctx(app_ctx)
+        app_ctx._session_branches[ctx_b.request_context.session] = "mcp/session-B"  # noqa: SLF001
+
+        result = await reset_or_switch_session_branch(ctx_a, None)
+
+        assert result["action"] == "reset"
+        assert app_ctx._session_branches[ctx_b.request_context.session] == "mcp/session-B"  # noqa: SLF001
+
+
+class TestReadOnlyWriteRecovery:
+    @staticmethod
+    def _client(*, status: BranchStatus) -> MagicMock:
+        client = MagicMock()
+        branch = MagicMock()
+        branch.status = status
+        branch.is_default = False
+        client.branch.get = AsyncMock(return_value=branch)
+        return client
+
+    async def test_merged_branch_confirmed_then_cleared_and_raises(self) -> None:
+        """Read-only error + Infrahub confirms MERGED → clear the branch and raise retryable."""
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+        app_ctx._session_branches[ctx.request_context.session] = "mcp/session-merged"  # noqa: SLF001
+        client = self._client(status=BranchStatus.MERGED)
+        exc = GraphQLError(errors=[{"message": "Branch 'mcp/session-merged' has been merged and is read-only"}])
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client), pytest.raises(ToolError, match="Retry"):
+            await _maybe_recover_read_only(ctx, exc)
+
+        assert ctx.request_context.session not in app_ctx._session_branches  # noqa: SLF001
+
+    async def test_read_only_attribute_error_does_not_clear(self) -> None:
+        """FR-011 false-positive guard: 'read-only' attribute error on a writable branch must NOT clear it."""
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+        app_ctx._session_branches[ctx.request_context.session] = "mcp/session-ok"  # noqa: SLF001
+        client = self._client(status=BranchStatus.OPEN)  # branch is actually fine
+        exc = GraphQLError(errors=[{"message": "Attribute 'name' is read-only and cannot be updated"}])
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            await _maybe_recover_read_only(ctx, exc)  # must NOT raise
+
+        assert app_ctx._session_branches[ctx.request_context.session] == "mcp/session-ok"  # noqa: SLF001
+
+    async def test_non_read_only_error_is_noop(self) -> None:
+        app_ctx = _app_ctx()
+        ctx = _make_ctx(app_ctx)
+        app_ctx._session_branches[ctx.request_context.session] = "mcp/session-ok"  # noqa: SLF001
+        client = MagicMock()
+        client.branch.get = AsyncMock()
+        exc = GraphQLError(errors=[{"message": "some unrelated validation failure"}])
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            await _maybe_recover_read_only(ctx, exc)  # returns without raising
+
+        assert app_ctx._session_branches[ctx.request_context.session] == "mcp/session-ok"  # noqa: SLF001
+        client.branch.get.assert_not_called()  # cheap pre-filter short-circuits, no round-trip
+
+
+class TestPrivilegedMutationGuard:
+    @pytest.mark.parametrize(
+        "query",
+        [
+            'mutation { BranchMerge(data: {name: "x"}) { ok } }',
+            'mutation { BranchRebase(data: {name: "x"}) { ok } }',
+            'mutation { BranchDelete(data: {name: "x"}) { ok } }',
+            'mutation { BranchCreate(data: {name: "x"}) { ok } }',
+            "mutation { SchemaDropdownAdd(data: {}) { ok } }",
+            "mutation { SchemaEnumRemove(data: {}) { ok } }",
+        ],
+    )
+    def test_blocks_privileged_mutations(self, query: str) -> None:
+        # Error must point the agent at the supported path (recovery guidance).
+        with pytest.raises(ToolError, match="reset_session_branch"):
+            _assert_no_privileged_mutations(query)
+
+    def test_blocks_privileged_mutation_in_inline_fragment(self) -> None:
+        # Must not be smuggled past the guard via a root inline fragment.
+        with pytest.raises(ToolError):
+            _assert_no_privileged_mutations('mutation { ... on Mutation { BranchMerge(data: {name: "x"}) { ok } } }')
+
+    def test_blocks_privileged_mutation_in_fragment_spread(self) -> None:
+        with pytest.raises(ToolError):
+            _assert_no_privileged_mutations(
+                'mutation { ...Evil } fragment Evil on Mutation { BranchMerge(data: {name: "x"}) { ok } }'
+            )
+
+    def test_rejects_non_mutation_operation(self) -> None:
+        # mutate_graphql must reject reads (and subscriptions) — use query_graphql instead.
+        with pytest.raises(ToolError, match="query_graphql"):
+            _assert_no_privileged_mutations("query { CoreTag { edges { node { id } } } }")
+
+    def test_allows_normal_node_mutation(self) -> None:
+        # A regular data mutation must pass through untouched.
+        _assert_no_privileged_mutations('mutation { CoreTagCreate(data: {name: {value: "web"}}) { ok } }')
+
+    def test_rejects_invalid_syntax(self) -> None:
+        with pytest.raises(ToolError, match="retry"):
+            _assert_no_privileged_mutations("mutation { broken(")

--- a/tests/unit/test_session_branch_validation.py
+++ b/tests/unit/test_session_branch_validation.py
@@ -1,83 +1,226 @@
-"""Tests for session branch validation against stale cache.
+"""Tests for per-session branch resolution, recovery, and name conformance.
 
-Regression coverage for the bug where ``AppContext.session_branch`` is cached
-for the lifetime of the MCP server process, but the underlying branch may
-have been deleted on Infrahub (merged proposed change, manual delete, dev
-server reset). Writes then 404 against the stale branch name until the
-server process restarts.
+The active session branch is tracked per MCP session (keyed by the session
+object) on ``AppContext``. The cached branch is validated against Infrahub
+before reuse; if it was deleted (``BranchNotFoundError``) or merged / is being
+removed (``status`` MERGED/DELETING — still present but read-only), the cache is
+cleared and a fresh branch is provisioned without a server restart.
 """
 
 from __future__ import annotations
 
+import asyncio
+import gc
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+from infrahub_sdk.branch import BranchStatus
 from infrahub_sdk.exceptions import BranchNotFoundError
 
 from infrahub_mcp.config import ServerConfig
-from infrahub_mcp.utils import AppContext, get_or_create_session_branch
+from infrahub_mcp.utils import (
+    AppContext,
+    branch_name_conforms,
+    get_or_create_session_branch,
+    get_session_branch,
+)
 
 
 def _make_ctx(app_ctx: AppContext) -> MagicMock:
-    """Create a mock FastMCP Context with the given AppContext."""
+    """Create a mock FastMCP Context with a stable per-session object."""
     ctx = MagicMock()
     ctx.request_context.lifespan_context = app_ctx
     ctx.info = AsyncMock()
     ctx.warning = AsyncMock()
     ctx.debug = AsyncMock()
+    ctx.error = AsyncMock()
     return ctx
+
+
+def _branch(status: BranchStatus) -> MagicMock:
+    branch = MagicMock()
+    branch.status = status
+    return branch
 
 
 class TestGetOrCreateSessionBranch:
     async def test_returns_cached_branch_when_it_still_exists(self) -> None:
-        """Cached branch is reused when it still exists on Infrahub — no re-create."""
+        """A still-writable cached branch is reused — no re-create."""
         config = ServerConfig(auth_mode="none")
-        app_ctx = AppContext(client=MagicMock(), config=config, session_branch="mcp/session-existing")
+        app_ctx = AppContext(client=MagicMock(), config=config)
+        ctx = _make_ctx(app_ctx)
+        app_ctx._session_branches[ctx.request_context.session] = "mcp/session-existing"  # noqa: SLF001
 
         client = MagicMock()
-        client.branch.get = AsyncMock(return_value=MagicMock())
+        client.branch.get = AsyncMock(return_value=_branch(BranchStatus.OPEN))
         client.branch.create = AsyncMock()
 
-        ctx = _make_ctx(app_ctx)
         with patch("infrahub_mcp.utils.get_client", return_value=client):
             result = await get_or_create_session_branch(ctx)
 
         assert result == "mcp/session-existing"
-        assert app_ctx.session_branch == "mcp/session-existing"
+        assert get_session_branch(ctx) == "mcp/session-existing"
         client.branch.create.assert_not_called()
         client.branch.get.assert_called_once_with(branch_name="mcp/session-existing")
 
+    @pytest.mark.parametrize("status", [BranchStatus.OPEN, BranchStatus.NEED_REBASE])
+    async def test_reuses_writable_statuses(self, status: BranchStatus) -> None:
+        """OPEN and NEED_REBASE branches are writable and reused."""
+        config = ServerConfig(auth_mode="none")
+        app_ctx = AppContext(client=MagicMock(), config=config)
+        ctx = _make_ctx(app_ctx)
+        app_ctx._session_branches[ctx.request_context.session] = "mcp/session-reuse"  # noqa: SLF001
+
+        client = MagicMock()
+        client.branch.get = AsyncMock(return_value=_branch(status))
+        client.branch.create = AsyncMock()
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            result = await get_or_create_session_branch(ctx)
+
+        assert result == "mcp/session-reuse"
+        client.branch.create.assert_not_called()
+
     async def test_recreates_when_cached_branch_was_deleted(self) -> None:
-        """Stale cached branch (deleted on server) triggers creation of a new one."""
+        """A deleted cached branch (BranchNotFoundError) triggers creation of a new one."""
         config = ServerConfig(auth_mode="none", branch_pattern="mcp/session-{date}-{hex}")
-        app_ctx = AppContext(client=MagicMock(), config=config, session_branch="mcp/session-stale")
+        app_ctx = AppContext(client=MagicMock(), config=config)
+        ctx = _make_ctx(app_ctx)
+        app_ctx._session_branches[ctx.request_context.session] = "mcp/session-stale"  # noqa: SLF001
 
         client = MagicMock()
         client.branch.get = AsyncMock(side_effect=BranchNotFoundError(identifier="mcp/session-stale"))
         client.branch.create = AsyncMock()
 
-        ctx = _make_ctx(app_ctx)
         with patch("infrahub_mcp.utils.get_client", return_value=client):
             result = await get_or_create_session_branch(ctx)
 
         assert result != "mcp/session-stale"
         assert result.startswith("mcp/session-")
-        assert app_ctx.session_branch == result
+        assert get_session_branch(ctx) == result
         client.branch.create.assert_called_once()
+        ctx.warning.assert_awaited()
+
+    @pytest.mark.parametrize("status", [BranchStatus.MERGED, BranchStatus.DELETING])
+    async def test_recovers_when_cached_branch_unwritable(self, status: BranchStatus) -> None:
+        """A merged/deleting cached branch (present but read-only) is recovered onto a new branch."""
+        config = ServerConfig(auth_mode="none", branch_pattern="mcp/session-{date}-{hex}")
+        app_ctx = AppContext(client=MagicMock(), config=config)
+        ctx = _make_ctx(app_ctx)
+        app_ctx._session_branches[ctx.request_context.session] = "mcp/session-merged"  # noqa: SLF001
+
+        client = MagicMock()
+        client.branch.get = AsyncMock(return_value=_branch(status))
+        client.branch.create = AsyncMock()
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            result = await get_or_create_session_branch(ctx)
+
+        assert result != "mcp/session-merged"
+        assert result.startswith("mcp/session-")
+        assert get_session_branch(ctx) == result
+        client.branch.create.assert_called_once()
+        ctx.warning.assert_awaited()  # SC-005: old + new named
 
     async def test_creates_when_no_cached_branch(self) -> None:
-        """First write of a process creates a new branch — no validation lookup."""
+        """First write of a session creates a new branch — no validation lookup."""
         config = ServerConfig(auth_mode="none", branch_pattern="mcp/session-{date}-{hex}")
-        app_ctx = AppContext(client=MagicMock(), config=config, session_branch=None)
+        app_ctx = AppContext(client=MagicMock(), config=config)
+        ctx = _make_ctx(app_ctx)
 
         client = MagicMock()
         client.branch.get = AsyncMock()
         client.branch.create = AsyncMock()
 
-        ctx = _make_ctx(app_ctx)
         with patch("infrahub_mcp.utils.get_client", return_value=client):
             result = await get_or_create_session_branch(ctx)
 
         assert result.startswith("mcp/session-")
-        assert app_ctx.session_branch == result
+        assert get_session_branch(ctx) == result
         client.branch.create.assert_called_once()
         client.branch.get.assert_not_called()
+
+    async def test_recovery_isolated_per_session(self) -> None:
+        """Recovery in one session does not touch another session's branch (FR-010 / SC-006)."""
+        config = ServerConfig(auth_mode="none", branch_pattern="mcp/session-{date}-{hex}")
+        app_ctx = AppContext(client=MagicMock(), config=config)
+        ctx_a = _make_ctx(app_ctx)
+        ctx_b = _make_ctx(app_ctx)
+        app_ctx._session_branches[ctx_a.request_context.session] = "mcp/session-A"  # noqa: SLF001
+        app_ctx._session_branches[ctx_b.request_context.session] = "mcp/session-B"  # noqa: SLF001
+
+        client = MagicMock()
+        client.branch.get = AsyncMock(return_value=_branch(BranchStatus.MERGED))
+        client.branch.create = AsyncMock()
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            await get_or_create_session_branch(ctx_a)
+
+        # Session B is untouched by Session A's recovery.
+        assert get_session_branch(ctx_b) == "mcp/session-B"
+        assert get_session_branch(ctx_a) != "mcp/session-A"
+
+    async def test_concurrent_first_writes_converge_on_one_branch(self) -> None:
+        """Concurrent writes in one session create exactly one branch (FR-008)."""
+        config = ServerConfig(auth_mode="none", branch_pattern="mcp/session-{date}-{hex}")
+        app_ctx = AppContext(client=MagicMock(), config=config)
+        ctx = _make_ctx(app_ctx)
+
+        client = MagicMock()
+        client.branch.get = AsyncMock(return_value=_branch(BranchStatus.OPEN))
+        client.branch.create = AsyncMock()
+
+        with patch("infrahub_mcp.utils.get_client", return_value=client):
+            first, second = await asyncio.gather(
+                get_or_create_session_branch(ctx),
+                get_or_create_session_branch(ctx),
+            )
+
+        assert first == second
+        client.branch.create.assert_called_once()
+
+
+class TestSessionStateLifecycle:
+    def test_session_entry_released_when_session_collected(self) -> None:
+        """Per-session entries are weakly held and released at session end (no leak — FR-010)."""
+        app_ctx = AppContext(client=MagicMock(), config=ServerConfig(auth_mode="none"))
+
+        class _Session:
+            """Stand-in for a per-session object (weak-referenceable)."""
+
+        sess = _Session()
+        app_ctx._session_branches[sess] = "mcp/session-x"  # noqa: SLF001
+        assert len(app_ctx._session_branches) == 1  # noqa: SLF001
+
+        del sess
+        gc.collect()
+
+        assert len(app_ctx._session_branches) == 0  # noqa: SLF001
+
+
+class TestBranchNameConforms:
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("mcp/session-20260604-ab12cd34", True),
+            ("mcp/session-2026-ab12cd34", False),  # {date} wrong length
+            ("mcp/session-20260604-ZZZZ", False),  # {hex} not 8 lowercase hex
+            ("totally-random-name", False),  # no match
+            ("mcp/session-20260604-ab12cd34/extra", False),  # trailing extra
+        ],
+    )
+    def test_default_pattern(self, name: str, expected: bool) -> None:
+        assert branch_name_conforms(name, "mcp/session-{date}-{hex}") is expected
+
+    def test_fixed_pattern_requires_exact_match(self) -> None:
+        assert branch_name_conforms("mybranch", "mybranch") is True
+        assert branch_name_conforms("other", "mybranch") is False
+
+    def test_user_placeholder_respects_separators(self) -> None:
+        assert branch_name_conforms("mcp/alice/work", "mcp/{user}/work") is True
+        assert branch_name_conforms("mcp/alice/nope", "mcp/{user}/work") is False
+        # {user} must not span literal '/' separators (would otherwise over-match).
+        assert branch_name_conforms("mcp/a/b/work", "mcp/{user}/work") is False
+
+    def test_rejects_disallowed_characters(self) -> None:
+        assert branch_name_conforms("mcp/session-20260604-ab12cd34 ", "mcp/session-{date}-{hex}") is False


### PR DESCRIPTION
## Summary

The MCP server caches one write branch per session, created lazily on the first write. Previously the cache was only invalidated when that branch was *deleted* — but in Infrahub a *merged* branch still exists and becomes read-only, so after merging the session branch (the intended end-of-work step) every subsequent write failed with `Branch ... has been merged and is read-only` until the server was restarted.

## Changes

- **Auto-recover stale branches** — validate `BranchData.status` before reuse and on a read-only write error; on a merged / deleting / missing branch, clear the cache and provision a fresh branch with no restart. The swap is reported to the caller (old → new).
- **Per-session scoping** — the session branch is keyed per MCP session via `WeakKeyDictionary`, so it is isolated between sessions and released automatically when a session ends (no unbounded growth).
- **`reset_session_branch` tool** — reset the session branch, or switch to a named branch (created when the name matches the configured `branch_pattern`).
- **Write hardening** — `mutate_graphql` is pinned to the session branch (no branch override) and rejects branch-/schema-management mutations and default-branch targets, so writes cannot bypass the `propose_changes` review gate.
- Every rejection returns an actionable next step for the caller.

## Testing

- Unit tests covering happy, error, recovery, conformance, isolation, and concurrency paths.
- A skip-guarded live integration suite (`tests/integration/`) that drives the tools end-to-end against a running Infrahub: merged-branch recovery, deleted-branch recovery, reset/switch/create, and the privileged-mutation block.
- `ruff`, `pylint` (10/10), `mypy`, `rumdl`, and the full `pytest` suite pass.

Design rationale: `dev/adr/0007-per-session-branch-recovery-and-reset.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically recover stale session branches and scope them per MCP session to stop cross-session interference. Adds a `reset_session_branch` tool, hardens writes so changes stay behind the review gate, and updates docs/capabilities.

- **New Features**
  - `reset_session_branch` to reset or switch the active branch (created if the name matches the configured pattern).
  - Write hardening: `mutate_graphql` uses the session branch only (no branch override) and rejects branch/schema management mutations and default-branch targets. Errors include the next step.

- **Bug Fixes**
  - Auto-recover when the cached branch is merged, deleting, or missing; clears the cache and provisions a fresh branch without restart, reporting old → new.
  - Per-session caching via weak references for true isolation and automatic cleanup.

<sup>Written for commit 22bd4b2e3bb3199de246df3fcfb5de8a11dd85ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-mcp/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

