### PR TITLE
feat(tests): Infrahub testcontainers integration suite (MVP)

### DIFF
--- a/.agents/commands/speckit.opsmill.extract.md
+++ b/.agents/commands/speckit.opsmill.extract.md
@@ -1,0 +1,344 @@
+---
+description: Extract knowledge, guidelines, and ADRs from one or more completed spec
+  directories into the project documentation system.
+---
+
+
+<!-- Extension: opsmill -->
+<!-- Config: .specify/extensions/opsmill/ -->
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+Goal: Analyze one or more completed spec directories and extract durable knowledge into the project's documentation system (`dev/knowledge/`, `dev/guidelines/`, `dev/adr/`), then mark each spec as extracted.
+
+This command accepts multiple specs as input (space-separated) and processes them sequentially. It operationalizes the documentation lifecycle: `specs/ → knowledge/ or guidelines/` (see `dev/guidelines/markdown.md`).
+
+## Phase 0: Setup & Validation
+
+<thinking>
+First, resolve all spec directories from the user's arguments and validate each one contains the expected artifacts.
+</thinking>
+
+1. **Parse arguments** — split `$ARGUMENTS` into individual spec identifiers (space-separated). If `$ARGUMENTS` is empty, list available spec directories and ask the user to pick one or more.
+
+2. **Resolve each spec directory**:
+   - For each identifier in the arguments:
+     - If it matches `specs/NNN-*` or `NNN-*`, resolve to `REPO_ROOT/specs/NNN-*`
+     - If it is a bare name like `graphql-name-lookup`, search `specs/` for a matching directory
+     - If no match found for an identifier, report it and continue resolving the rest
+   - If **no** identifiers could be resolved, list available spec directories and ask the user to pick
+
+3. **Validate each resolved spec**:
+   - `spec.md` MUST exist — skip that spec with an error if missing
+   - `research.md` SHOULD exist — warn if missing ("No ADRs can be extracted without research.md") but continue
+
+4. **Check extraction status** for each spec:
+   - If `EXTRACTED.md` exists in the spec directory, warn the user that this spec was previously extracted
+   - Also check if the spec already lives under `specs/archive/` — if so, it was previously extracted and archived
+   - Ask for confirmation before re-extracting — default is abort
+   - The user can choose to skip individual specs from the batch
+
+5. **Summarize resolved specs** — before proceeding, print the list of specs that will be processed:
+   ```
+   Processing N spec(s):
+   1. specs/<spec-name-1>
+   2. specs/<spec-name-2>
+   ...
+   ```
+
+6. **Load existing documentation index** (once, shared across all specs):
+   - List all files in `dev/knowledge/` (recursively)
+   - List all files in `dev/guidelines/` (recursively)
+   - List all files in `dev/adr/` to determine the next ADR number
+   - Read the first 20 lines of each knowledge and guidelines file to build a topic index (title + overview section)
+
+7. **Load spec artifacts** — for each spec, read all available files from its directory:
+   - `research.md` (primary source for ADRs)
+   - `spec.md` (context, scope decisions)
+   - `data-model.md` (schema changes, new methods — if exists)
+   - All files in `contracts/` (API changes — if exists)
+   - `plan.md` (architectural context — if exists)
+
+## Phase 1: Analysis & Classification
+
+<thinking>
+For each spec, I need to parse each source and classify content into three buckets: ADR, Knowledge, Guideline. I should also identify content to skip with a clear reason. I'll process specs sequentially and tag each finding with its source spec.
+</thinking>
+
+Repeat the following steps for **each resolved spec directory**. Tag every finding with the source spec name so the extraction plan in Phase 2 groups items by spec.
+
+### Step 1: Extract ADR candidates from research.md
+
+Parse each `## R#` section in `research.md`. For each entry:
+
+1. Extract: Decision, Rationale, Alternatives considered, Implementation pattern
+2. Determine if it is ADR-worthy using this heuristic:
+   - **ADR-worthy**: Affects system structure, API contracts, data models, error handling strategy, or establishes a pattern used across multiple components
+   - **Not ADR-worthy**: One-off implementation detail with no broader implications (e.g., a local variable naming choice, a single method signature)
+3. Draft an ADR title (concise, decision-focused — e.g., "Dual identifier resolution via service-layer helpers")
+
+Also scan `spec.md` for scope decisions or trade-offs in the Clarifications or Assumptions sections that represent architectural choices worth recording.
+
+### Step 2: Extract knowledge candidates
+
+Scan for content that describes **how the system works after the feature**:
+
+| Source | What to look for | Target file |
+|--------|-----------------|-------------|
+| `data-model.md` | New entities, fields, relationships, constraints | `dev/knowledge/backend/data-models.md` |
+| `contracts/` | New or changed GraphQL queries, mutations, types | `dev/knowledge/backend/api.md` |
+| `research.md` | New service patterns, architectural patterns | `dev/knowledge/backend/services.md` or relevant file |
+| `spec.md` | New concepts or domain terminology | `dev/knowledge/backend/overview.md` or relevant file |
+
+For each finding, map it to a specific existing knowledge file and section. If no existing file fits, propose a new file with a name following `kebab-case.md` convention.
+
+### Step 3: Extract guideline candidates
+
+Scan `research.md` for implementation patterns that establish **repeatable, prescriptive conventions** for future code:
+
+- New parameter patterns → `dev/guidelines/backend/python.md` or `dev/guidelines/cyclopts.md`
+- New error handling conventions → `dev/guidelines/backend/python.md`
+- New API design conventions → `dev/guidelines/backend/graphql.md` (create if needed)
+- New testing patterns → relevant guidelines file
+
+Only extract patterns that are **prescriptive** (should be followed in future code). Do NOT extract patterns that are merely **descriptive** of how this specific feature works — those belong in knowledge.
+
+### Step 4: Identify skipped content
+
+For each piece of spec content not classified above, note it with a reason:
+- Execution artifacts (`plan.md`, `quickstart.md`) — no durable knowledge
+- Implementation details already captured in code — no need to duplicate
+- One-off decisions with no broader applicability
+
+## Phase 2: Interactive Review
+
+Present findings in a structured extraction plan. When processing multiple specs, group the plan by spec. Use a **global numbering scheme** across all specs so that item numbers are unique (e.g., spec 1 items are 1–4, spec 2 items are 5–8).
+
+Use this format:
+
+```markdown
+## Extraction Plan
+
+### specs/<spec-name-1>
+
+#### ADRs to Create (<count>)
+
+| # | Source | Title | Target File |
+|---|--------|-------|-------------|
+| 1 | R1 | <title> | dev/adr/nnnn-<slug>.md |
+| 2 | R2 | <title> | dev/adr/nnnn-<slug>.md |
+
+#### Knowledge Updates (<count>)
+
+| # | Target File | Section | Change | Summary |
+|---|-------------|---------|--------|---------|
+| 3 | dev/knowledge/backend/api.md | Queries | UPDATE | <what changes> |
+
+#### Guidelines Updates (<count>)
+
+| # | Target File | Section | Change | Summary |
+|---|-------------|---------|--------|---------|
+| 4 | dev/guidelines/backend/python.md | Error Handling | UPDATE | <what changes> |
+
+#### Skipped (with reasons)
+
+| Source | Reason |
+|--------|--------|
+| plan.md | Execution artifact — no durable knowledge |
+
+---
+
+### specs/<spec-name-2>
+
+#### ADRs to Create (<count>)
+
+| # | Source | Title | Target File |
+|---|--------|-------|-------------|
+| 5 | R1 | <title> | dev/adr/nnnn-<slug>.md |
+
+...
+```
+
+When processing a single spec, omit the per-spec grouping headers and use the simpler flat format (same as the multi-spec table structure but without the `### specs/<name>` wrapper).
+
+After presenting, tell the user:
+
+> **Actions:**
+> - `approve all` — proceed with all extractions across all specs
+> - `approve spec <name>` — approve all items for a specific spec
+> - `approve adrs` / `approve knowledge` / `approve guidelines` — approve by category (across all specs)
+> - `skip N` — skip a specific numbered item
+> - `edit N` — modify a specific item before writing
+> - `group N,M` — merge multiple ADR items into a single ADR
+
+Wait for user response before proceeding. Do NOT write any files until the user approves.
+
+## Phase 3: Write Extractions
+
+For each approved item across all specs, write the content. ADR numbering is sequential across all specs (i.e., if spec 1 creates `0005` and `0006`, spec 2 starts at `0007`).
+
+### ADRs
+
+Create new files in `dev/adr/` using this format:
+
+```markdown
+# N. <Title>
+
+**Status**: Accepted
+**Date**: <today's date YYYY-MM-DD>
+**Source**: specs/archive/<spec-name>/research.md (R#)
+
+## Context
+
+<What is the issue that motivates this decision? Derive from the feature context in spec.md and the specific problem the R# entry addresses.>
+
+## Decision
+
+<What was decided. Taken from the Decision field of the R# entry.>
+
+## Consequences
+
+<What becomes easier or harder as a result. Synthesize from the Rationale and any implementation notes.>
+
+## Alternatives Considered
+
+<What other options were evaluated and why they were rejected. Taken from the Alternatives considered field.>
+```
+
+**Numbering**: Read existing files in `dev/adr/` to find the highest existing ADR number. Start new ADRs at the next sequential number. Zero-pad the **filename** sequence to **4 digits** (e.g., `0001`, `0012`); the H1 heading uses the un-padded number (e.g., `# 1.`, `# 12.`).
+
+**File naming**: canonical MADR `nnnn-kebab-case-short-title.md` — 4-digit zero-padded sequence, lowercase kebab title, **no** `adr-`/`ADR-` prefix (e.g., `0001-schema-changes-without-migrations.md`).
+
+### Knowledge updates
+
+For each knowledge update:
+1. Read the full target file
+2. Find the appropriate section (match by heading)
+3. Add or update content within that section
+4. If the section does not exist, create it in a logical position
+5. Add a source marker: `<!-- Extracted from specs/<spec-name> on YYYY-MM-DD -->`
+
+### Guidelines updates
+
+Same approach as knowledge updates:
+1. Read the full target file (or create a new one if needed)
+2. Find the appropriate section
+3. Add the prescriptive pattern with code examples where relevant
+4. Add a source marker: `<!-- Extracted from specs/<spec-name> on YYYY-MM-DD -->`
+
+If creating a new guidelines file, follow the standard structure:
+```markdown
+# <Topic> Guidelines
+
+## Overview
+
+<Brief description of what this document covers.>
+
+## <Sections...>
+```
+
+## Phase 4: Cleanup & Report
+
+Perform the following steps for **each spec** that had approved extractions.
+
+### 1. Create extraction record
+
+Write `EXTRACTED.md` in each spec directory:
+
+```markdown
+# Extraction Record
+
+**Extracted on**: <YYYY-MM-DD>
+**Extracted by**: speckit.opsmill.extract
+
+## ADRs Created
+
+- <path to ADR file> (from R#)
+- ...
+
+## Knowledge Updated
+
+- <path to knowledge file> (<section name>)
+- ...
+
+## Guidelines Updated
+
+- <path to guidelines file> (<section name>)
+- ...
+
+## Archive
+
+Spec directory moved to `specs/archive/<spec-name>/` as a historical record.
+```
+
+### 2. Update spec status and archive
+
+For each spec:
+1. In `spec.md`, update or add the status field to: `**Status**: Extracted`
+2. Move the entire spec directory into `specs/archive/`:
+   ```bash
+   mkdir -p specs/archive
+   mv specs/<spec-name> specs/archive/<spec-name>
+   ```
+   This makes it immediately clear which specs have been processed and which are still active.
+
+### 3. Update dev/README.md
+
+After **all** specs have been processed, update `dev/README.md` once with all new files:
+- If any **new** files were created in `dev/knowledge/`, `dev/guidelines/`, or `dev/adr/`:
+  - Read `dev/README.md`
+  - Add new entries to the appropriate section (Current Guidelines, Current Knowledge, or a new Current ADRs section)
+  - Follow the existing link format: `- [filename.md](path/to/filename.md) - Brief description`
+- If `dev/adr/` now has content and there is no "Current ADRs" section in the README, create one following the pattern of the existing sections.
+
+### 4. Report
+
+Print a combined summary covering all processed specs:
+
+```markdown
+## Extraction Complete
+
+**Date**: YYYY-MM-DD
+**Specs processed**: N
+
+### Per-Spec Summary
+
+| Spec | ADRs | Knowledge | Guidelines | Status |
+|------|------|-----------|------------|--------|
+| specs/<spec-name-1> | N | N | N | archived |
+| specs/<spec-name-2> | N | N | N | archived |
+
+### Totals
+- N ADR(s) created in dev/adr/
+- N knowledge file(s) updated
+- N guideline file(s) updated
+
+### Archived
+- specs/<spec-name-1> → specs/archive/<spec-name-1>
+- specs/<spec-name-2> → specs/archive/<spec-name-2>
+
+### Files Created/Modified
+- <list each file path>
+
+### Next Steps
+- Review the created ADRs for accuracy
+- Verify knowledge and guideline updates read well in context
+```
+
+
+## Behavior Rules
+
+- **Never write files without user approval** in Phase 2
+- If analysis finds nothing to extract (empty across all categories), report cleanly: "No extractable content found in this spec." and skip the review phase
+- If a knowledge file section already contains similar content, flag it for user review rather than duplicating
+- Do not reformat or restructure existing content in knowledge/guidelines files beyond the specific additions
+- Always create `specs/archive/` before moving if it does not exist
+- ADR `Source` paths must reference the archive location (`specs/archive/<spec-name>/`) since the spec will be moved there
+- For single quotes in bash args, use escape syntax: e.g. `'I'\''m Groot'` (or double-quote if possible: `"I'm Groot"`)

--- a/.agents/commands/speckit.opsmill.retrospect.md
+++ b/.agents/commands/speckit.opsmill.retrospect.md
@@ -1,0 +1,179 @@
+---
+description: Run a session retrospective that surfaces context-management gaps and
+  routes them to approved follow-up actions.
+---
+
+
+<!-- Extension: opsmill -->
+<!-- Config: .specify/extensions/opsmill/ -->
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty). Treat it as optional scope guidance, such as a focus area, a pasted transcript summary, or a preferred disposition.
+
+## Outline
+
+Run a retrospective on the current agent session while the work is still fresh in context. The goal is to identify concrete improvements to the repository's context-management surface area: `AGENTS.md`, `CLAUDE.md`, `.claude/settings.json`, `.agents/skills/`, `.agents/commands/`, `.specify/templates/`, `dev/knowledge/`, `dev/guides/`, `dev/guidelines/`, `dev/adr/`, and product or architecture decisions that caused avoidable friction.
+
+This command closes the loop from "the agent struggled with X" to "X is captured as an approved repo improvement, dedicated PR, GitHub issue, or local-only note."
+
+## Operating Constraints
+
+- Stay read-only until the user approves the report and any disposition buckets. Do not edit files, commit, push, or create GitHub issues before approval.
+- Present the full retrospective before taking action. Ask for explicit approval per disposition bucket: `fix-now`, `open-pr`, `github-issue`, and `local-only`.
+- For `fix-now`, present a diff preview or precise patch plan before writing files. Apply only the approved changes.
+- For `github-issue`, defer to the existing `create-issue` skill when available; if it is unavailable, use `gh issue create` only after the user approves the exact issue content.
+- Respect `AGENTS.md` guardrails. Ask First topics, including database migrations, GraphQL schema changes, new dependencies, CI/CD workflow changes, and authentication or authorization changes, are never auto-applied. Route them to `open-pr` or `github-issue`.
+- Never edit generated files. If a finding points at generated output, identify the source template or generator instead.
+- Do not treat personal preferences as repo policy. Use `local-only` for non-project-specific workflow preferences.
+
+## Phase 1: Resolve Session Context
+
+1. Identify the repository root and current branch:
+   - Run `git rev-parse --show-toplevel`.
+   - Run `git branch --show-current`.
+   - Run `git status --short` to understand whether there are existing edits.
+2. Determine whether the session is inside an active spec-kit feature:
+   - Try `.specify/scripts/bash/check-prerequisites.sh --json --paths-only`.
+   - If it succeeds, record `FEATURE_DIR` and use `FEATURE_DIR/retrospective.md` as the report path.
+   - If it fails or the project is not on a spec-kit feature branch, continue as an ad-hoc session and use `.claude/retrospectives/YYYYMMDD-HHMMSS-<short-branch-or-session-slug>.md` as the report path.
+3. Load only the context needed to classify findings:
+   - Root `AGENTS.md` and any area-specific `AGENTS.md` touched this session.
+   - `CLAUDE.md` and `.claude/settings.json` if present.
+   - Relevant skill prompts in `.agents/skills/` and commands in `.agents/commands/`.
+   - Relevant spec-kit templates in `.specify/templates/`.
+   - Relevant `dev/knowledge/`, `dev/guides/`, `dev/guidelines/`, or `dev/adr/` pages.
+   - Current diff and recent commands from the conversation context.
+
+## Phase 2: Identify Findings
+
+Review the current conversation and repository context for friction that was avoidable through better shared context. Organize findings into exactly these categories:
+
+1. **Instructions / Configuration Gaps**
+   - Missing, unclear, duplicated, or contradictory guidance in `AGENTS.md`, `CLAUDE.md`, `.claude/settings.json`, skill prompts, commands, or spec-kit templates.
+   - Required repo workflows that the agent had to infer or rediscover.
+2. **Documentation Gaps**
+   - Missing or stale content in `dev/knowledge/`, `dev/guides/`, `dev/guidelines/`, or `dev/adr/`.
+   - Docs that contradicted current code or left out required verification steps.
+3. **Architectural Friction**
+   - Product, architecture, or code choices that forced repeated workarounds.
+   - Candidates for ADRs, refactors, or product follow-up.
+4. **Mistakes & Corrections**
+   - Wrong turns taken during the session.
+   - The guardrail, instruction, template change, or test that would have prevented the mistake.
+
+Prefer concrete findings over broad observations. Each finding must cite the session event or repository location that motivated it.
+
+## Phase 3: Assign Dispositions
+
+For each finding, propose one disposition:
+
+| Disposition | Use When | Action After Approval |
+|-------------|----------|-----------------------|
+| `fix-now` | Small, low-risk repo context updates that belong on the current branch and do not touch Ask First topics. | Show diff preview, then edit files only after approval. |
+| `open-pr` | Context or harness changes that should be reviewed separately from the current feature branch, or anything touching Ask First topics. | Draft a branch/PR plan. Do not branch, commit, push, or open a PR unless explicitly approved. |
+| `github-issue` | Larger work, ambiguous ownership, product/architecture debt, ADR candidates needing human authorship, or work outside current scope. | Use the `create-issue` skill to draft each issue; create only after approval. |
+| `local-only` | Personal workflow preferences or notes that should not become repo policy. | Record only in approved local .specify/memory/report locations supported by the runtime. |
+
+Disposition rules:
+
+- If a finding involves database schema or migration changes, GraphQL schema changes, new dependencies, CI/CD workflows, authentication, authorization, or generated files, do not assign `fix-now`.
+- If a finding needs product or architecture ownership, prefer `github-issue` unless the user explicitly asks for a dedicated PR.
+- If a finding is already fully covered by existing docs or instructions, do not include it as a finding; mention it only in a brief "No action" note if helpful.
+
+## Phase 4: Produce Review Report
+
+Before writing any files, present the retrospective in chat using this structure:
+
+```markdown
+## Session Retrospective
+
+**Scope**: <current feature, branch, or ad-hoc session>
+**Proposed report path**: <path>
+
+### Findings
+
+| ID | Category | Evidence | Improvement | Disposition |
+|----|----------|----------|-------------|-------------|
+| R1 | Instructions / Configuration Gaps | <specific session event or file path> | <concrete change> | fix-now |
+
+### Disposition Buckets
+
+#### fix-now
+
+- R1: <target file and change summary>
+
+#### open-pr
+
+- R2: <branch or PR scope>
+
+#### github-issue
+
+- R3: <issue title>
+
+#### local-only
+
+- R4: <memory/report note>
+
+### Approval Request
+
+Reply with one or more approved buckets, for example:
+
+- `approve report only`
+- `approve fix-now`
+- `approve github-issue R3`
+- `approve all except open-pr`
+```
+
+The report must include concrete findings in all four categories. If a category genuinely has no findings, include the category with `None found` and a one-sentence reason.
+
+## Phase 5: Save Report
+
+Save the retrospective report only after the user approves `report only`, a disposition bucket, or `all`.
+
+Report path:
+
+- Active spec-kit feature: `specs/<current-feature>/retrospective.md`.
+- Ad-hoc session: `.claude/retrospectives/YYYYMMDD-HHMMSS-<short-branch-or-session-slug>.md`.
+
+If the report path already exists, append a numeric suffix rather than overwriting it.
+
+## Phase 6: Execute Approved Dispositions
+
+Process only the buckets the user approved.
+
+### fix-now
+
+1. Show a diff preview or exact patch plan for the approved findings.
+2. Wait for confirmation if the preview changes the original scope.
+3. Apply edits with normal repository editing rules.
+4. Run relevant validation. For prompt, command, and Markdown-only changes, at minimum verify paths exist and the command can be discovered from the extension manifest and runtime command file. Run broader lint or tests when touched files are covered by existing automation.
+
+### open-pr
+
+1. Draft the proposed branch name, PR title, PR body summary, and changed file list.
+2. Ask for explicit approval before creating a branch, committing, pushing, or opening a PR.
+3. If approved, use the repository's normal PR workflow.
+
+### github-issue
+
+1. For each approved finding, invoke the `create-issue` skill with the finding as source material.
+2. Present the exact issue title/body/labels for approval.
+3. Create issues only after approval.
+
+### local-only
+
+1. Record the note only in runtime-supported local memory or in the approved retrospective report.
+2. Do not add local-only preferences to repo files unless the user explicitly reclassifies them as repo policy.
+
+## Completion
+
+After approved actions are complete, provide a brief summary:
+
+- Report path
+- Actions taken
+- Validation run
+- Any remaining unapproved buckets

--- a/.agents/commands/speckit.opsmill.summary.md
+++ b/.agents/commands/speckit.opsmill.summary.md
@@ -1,0 +1,144 @@
+---
+description: Produce a flow-level summary of the current Claude Code session — executive
+  summary, chronological timeline, and outcomes — written into the active feature
+  directory next to spec.md / plan.md.
+scripts:
+  sh: .specify/scripts/bash/check-prerequisites.sh --json --paths-only
+  ps: .specify/scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly
+---
+
+
+<!-- Extension: opsmill -->
+<!-- Config: .specify/extensions/opsmill/ -->
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+Supported argument: `--since <commit|time>` to bound the summary window.
+Examples:
+
+- `--since HEAD~10` — limit the timeline to phases that began after the
+  10th-most-recent commit on this branch.
+- `--since 14:00` — only include phases that occurred after 2 PM local time
+  in the active session.
+
+If no argument is given, summarize the **entire live session**.
+
+## Goal
+
+Produce a single markdown document that lets a teammate (or future-you)
+understand the *flow* of the session in under 60 seconds. The unit of
+output is the working session, not any one artifact. Different
+granularity from `speckit.archive` (per-feature, permanent) and
+`speckit.reconcile.run` (drift-fixing).
+
+## Operating Constraints
+
+**STAY AT THE FLOW LEVEL.** This summary is a narrative, not a
+transcript. Do **NOT** include any of the following:
+
+- Per-tool-call narration ("called Read on X.py, then called Edit on...")
+- Diffs or hunks of any size
+- Line numbers
+- Code snippets longer than a single line
+- File-by-file change logs (those belong in PR descriptions and `git log`)
+- Step-by-step reproductions of debugging
+- Quotes from the conversation buffer longer than one short clause
+
+**STRICTLY ADDITIVE.** Do not modify `spec.md`, `plan.md`, `tasks.md`,
+or any source files. The only file this command writes is the session
+summary itself.
+
+**IDEMPOTENT IN SPIRIT.** A second invocation in the same session must
+produce a comparable summary, not a summary of summaries. Ignore
+previously generated session files when composing the new one.
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` from repo root and parse `FEATURE_DIR` from the JSON
+   output. All paths must be absolute.
+
+   - If `FEATURE_DIR` is missing, empty, or the resolved directory does
+     not exist, **fail fast** with a clear error such as:
+     `No feature directory resolved from current branch — /speckit.opsmill.summary requires an active feature branch.`
+     Suggest the user switch to a feature branch and re-run.
+
+2. Parse `$ARGUMENTS` for an optional `--since <value>`. Treat the
+   value as opaque — pass it through to `git log --since=<value>` if it
+   parses as a date/time, otherwise treat it as a git revision and use
+   `git log <value>..HEAD`. Do not attempt to interpret it any further.
+
+3. **Gather context** for the summary, in this order of preference:
+
+   a. The live conversation context (primary source — the actual
+      session is what is being summarized).
+   b. `git log` on the current branch, optionally bounded by `--since`,
+      for outcomes that already landed as commits.
+   c. `FEATURE_DIR/spec.md`, `plan.md`, `tasks.md` if they exist — only
+      to anchor terminology, not to copy content.
+
+   Do **not** read every changed file. Do **not** generate diffs. Stay
+   at the level of "what phase of work was happening, and what did it
+   produce".
+
+4. **Compose the summary** with exactly these three sections, in this
+   order:
+
+   ### Executive Summary
+
+   One paragraph (2–4 sentences). What was this session about? What was
+   the working theme? Reading just this paragraph should answer "what
+   did they spend their time on today?".
+
+   ### Timeline
+
+   A chronological bullet list. Each entry is a single short line in
+   the form `HH:MM — <human-readable phase>`, e.g.:
+
+   - `10:42 — investigated failing E2E test in deployments_create.py`
+   - `11:05 — narrowed cause to driver init order`
+   - `11:30 — applied fix and re-ran suite`
+
+   Aim for 5–15 entries. Collapse near-duplicate phases (e.g. three
+   consecutive "ran tests" lines into one). If exact timestamps are not
+   recoverable, use relative ordering with no `HH:MM` prefix and a
+   leading dash only.
+
+   ### Outcomes
+
+   A short bullet list of concrete results from the session. Reference
+   paths and PRs only — no diffs. Examples:
+
+   - Opened PR #161 (speckit-extensions cleanup).
+   - Materially changed `.specify/extensions/auto/`, `tinyspec/`.
+   - Decided: extensions invoke skills, not slash commands.
+   - Deferred: rewriting the auto extension's hook condition DSL.
+
+5. **Write the file.**
+
+   - Path: `FEATURE_DIR/sessions/session-YYYY-MM-DD-HHMM.md`, where
+     `YYYY-MM-DD-HHMM` is the local time at invocation.
+   - Create `FEATURE_DIR/sessions/` if it does not exist.
+   - If a file with the same `HHMM` already exists, append a numeric
+     suffix (`-2`, `-3`, …) rather than overwriting.
+
+6. **Print the resolved path** back to the user as the final message,
+   plus a one-line reminder that the summary is intentionally
+   high-level and the conversation transcript / `git log` remain the
+   sources of truth for detail.
+
+## Quality Bar
+
+A reader who was not in the session should, after under 60 seconds with
+the document, be able to answer:
+
+- What was the session trying to accomplish?
+- What was the rough order of work?
+- What concretely shipped, what was decided, what was deferred?
+
+If the draft cannot pass that bar, tighten it before writing. If it
+exceeds ~80 lines of markdown, you are too detailed — cut.

--- a/.agents/skills/speckit-opsmill-extract/SKILL.md
+++ b/.agents/skills/speckit-opsmill-extract/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: speckit-opsmill-extract
+description: Extract knowledge, guidelines, and ADRs from one or more completed spec
+  directories into the project documentation system.
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: opsmill:commands/extract.md
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+Goal: Analyze one or more completed spec directories and extract durable knowledge into the project's documentation system (`dev/knowledge/`, `dev/guidelines/`, `dev/adr/`), then mark each spec as extracted.
+
+This command accepts multiple specs as input (space-separated) and processes them sequentially. It operationalizes the documentation lifecycle: `specs/ → knowledge/ or guidelines/` (see `dev/guidelines/markdown.md`).
+
+## Phase 0: Setup & Validation
+
+<thinking>
+First, resolve all spec directories from the user's arguments and validate each one contains the expected artifacts.
+</thinking>
+
+1. **Parse arguments** — split `$ARGUMENTS` into individual spec identifiers (space-separated). If `$ARGUMENTS` is empty, list available spec directories and ask the user to pick one or more.
+
+2. **Resolve each spec directory**:
+   - For each identifier in the arguments:
+     - If it matches `specs/NNN-*` or `NNN-*`, resolve to `REPO_ROOT/specs/NNN-*`
+     - If it is a bare name like `graphql-name-lookup`, search `specs/` for a matching directory
+     - If no match found for an identifier, report it and continue resolving the rest
+   - If **no** identifiers could be resolved, list available spec directories and ask the user to pick
+
+3. **Validate each resolved spec**:
+   - `spec.md` MUST exist — skip that spec with an error if missing
+   - `research.md` SHOULD exist — warn if missing ("No ADRs can be extracted without research.md") but continue
+
+4. **Check extraction status** for each spec:
+   - If `EXTRACTED.md` exists in the spec directory, warn the user that this spec was previously extracted
+   - Also check if the spec already lives under `specs/archive/` — if so, it was previously extracted and archived
+   - Ask for confirmation before re-extracting — default is abort
+   - The user can choose to skip individual specs from the batch
+
+5. **Summarize resolved specs** — before proceeding, print the list of specs that will be processed:
+   ```
+   Processing N spec(s):
+   1. specs/<spec-name-1>
+   2. specs/<spec-name-2>
+   ...
+   ```
+
+6. **Load existing documentation index** (once, shared across all specs):
+   - List all files in `dev/knowledge/` (recursively)
+   - List all files in `dev/guidelines/` (recursively)
+   - List all files in `dev/adr/` to determine the next ADR number
+   - Read the first 20 lines of each knowledge and guidelines file to build a topic index (title + overview section)
+
+7. **Load spec artifacts** — for each spec, read all available files from its directory:
+   - `research.md` (primary source for ADRs)
+   - `spec.md` (context, scope decisions)
+   - `data-model.md` (schema changes, new methods — if exists)
+   - All files in `contracts/` (API changes — if exists)
+   - `plan.md` (architectural context — if exists)
+
+## Phase 1: Analysis & Classification
+
+<thinking>
+For each spec, I need to parse each source and classify content into three buckets: ADR, Knowledge, Guideline. I should also identify content to skip with a clear reason. I'll process specs sequentially and tag each finding with its source spec.
+</thinking>
+
+Repeat the following steps for **each resolved spec directory**. Tag every finding with the source spec name so the extraction plan in Phase 2 groups items by spec.
+
+### Step 1: Extract ADR candidates from research.md
+
+Parse each `## R#` section in `research.md`. For each entry:
+
+1. Extract: Decision, Rationale, Alternatives considered, Implementation pattern
+2. Determine if it is ADR-worthy using this heuristic:
+   - **ADR-worthy**: Affects system structure, API contracts, data models, error handling strategy, or establishes a pattern used across multiple components
+   - **Not ADR-worthy**: One-off implementation detail with no broader implications (e.g., a local variable naming choice, a single method signature)
+3. Draft an ADR title (concise, decision-focused — e.g., "Dual identifier resolution via service-layer helpers")
+
+Also scan `spec.md` for scope decisions or trade-offs in the Clarifications or Assumptions sections that represent architectural choices worth recording.
+
+### Step 2: Extract knowledge candidates
+
+Scan for content that describes **how the system works after the feature**:
+
+| Source | What to look for | Target file |
+|--------|-----------------|-------------|
+| `data-model.md` | New entities, fields, relationships, constraints | `dev/knowledge/backend/data-models.md` |
+| `contracts/` | New or changed GraphQL queries, mutations, types | `dev/knowledge/backend/api.md` |
+| `research.md` | New service patterns, architectural patterns | `dev/knowledge/backend/services.md` or relevant file |
+| `spec.md` | New concepts or domain terminology | `dev/knowledge/backend/overview.md` or relevant file |
+
+For each finding, map it to a specific existing knowledge file and section. If no existing file fits, propose a new file with a name following `kebab-case.md` convention.
+
+### Step 3: Extract guideline candidates
+
+Scan `research.md` for implementation patterns that establish **repeatable, prescriptive conventions** for future code:
+
+- New parameter patterns → `dev/guidelines/backend/python.md` or `dev/guidelines/cyclopts.md`
+- New error handling conventions → `dev/guidelines/backend/python.md`
+- New API design conventions → `dev/guidelines/backend/graphql.md` (create if needed)
+- New testing patterns → relevant guidelines file
+
+Only extract patterns that are **prescriptive** (should be followed in future code). Do NOT extract patterns that are merely **descriptive** of how this specific feature works — those belong in knowledge.
+
+### Step 4: Identify skipped content
+
+For each piece of spec content not classified above, note it with a reason:
+- Execution artifacts (`plan.md`, `quickstart.md`) — no durable knowledge
+- Implementation details already captured in code — no need to duplicate
+- One-off decisions with no broader applicability
+
+## Phase 2: Interactive Review
+
+Present findings in a structured extraction plan. When processing multiple specs, group the plan by spec. Use a **global numbering scheme** across all specs so that item numbers are unique (e.g., spec 1 items are 1–4, spec 2 items are 5–8).
+
+Use this format:
+
+```markdown
+## Extraction Plan
+
+### specs/<spec-name-1>
+
+#### ADRs to Create (<count>)
+
+| # | Source | Title | Target File |
+|---|--------|-------|-------------|
+| 1 | R1 | <title> | dev/adr/nnnn-<slug>.md |
+| 2 | R2 | <title> | dev/adr/nnnn-<slug>.md |
+
+#### Knowledge Updates (<count>)
+
+| # | Target File | Section | Change | Summary |
+|---|-------------|---------|--------|---------|
+| 3 | dev/knowledge/backend/api.md | Queries | UPDATE | <what changes> |
+
+#### Guidelines Updates (<count>)
+
+| # | Target File | Section | Change | Summary |
+|---|-------------|---------|--------|---------|
+| 4 | dev/guidelines/backend/python.md | Error Handling | UPDATE | <what changes> |
+
+#### Skipped (with reasons)
+
+| Source | Reason |
+|--------|--------|
+| plan.md | Execution artifact — no durable knowledge |
+
+---
+
+### specs/<spec-name-2>
+
+#### ADRs to Create (<count>)
+
+| # | Source | Title | Target File |
+|---|--------|-------|-------------|
+| 5 | R1 | <title> | dev/adr/nnnn-<slug>.md |
+
+...
+```
+
+When processing a single spec, omit the per-spec grouping headers and use the simpler flat format (same as the multi-spec table structure but without the `### specs/<name>` wrapper).
+
+After presenting, tell the user:
+
+> **Actions:**
+> - `approve all` — proceed with all extractions across all specs
+> - `approve spec <name>` — approve all items for a specific spec
+> - `approve adrs` / `approve knowledge` / `approve guidelines` — approve by category (across all specs)
+> - `skip N` — skip a specific numbered item
+> - `edit N` — modify a specific item before writing
+> - `group N,M` — merge multiple ADR items into a single ADR
+
+Wait for user response before proceeding. Do NOT write any files until the user approves.
+
+## Phase 3: Write Extractions
+
+For each approved item across all specs, write the content. ADR numbering is sequential across all specs (i.e., if spec 1 creates `0005` and `0006`, spec 2 starts at `0007`).
+
+### ADRs
+
+Create new files in `dev/adr/` using this format:
+
+```markdown
+# N. <Title>
+
+**Status**: Accepted
+**Date**: <today's date YYYY-MM-DD>
+**Source**: specs/archive/<spec-name>/research.md (R#)
+
+## Context
+
+<What is the issue that motivates this decision? Derive from the feature context in spec.md and the specific problem the R# entry addresses.>
+
+## Decision
+
+<What was decided. Taken from the Decision field of the R# entry.>
+
+## Consequences
+
+<What becomes easier or harder as a result. Synthesize from the Rationale and any implementation notes.>
+
+## Alternatives Considered
+
+<What other options were evaluated and why they were rejected. Taken from the Alternatives considered field.>
+```
+
+**Numbering**: Read existing files in `dev/adr/` to find the highest existing ADR number. Start new ADRs at the next sequential number. Zero-pad the **filename** sequence to **4 digits** (e.g., `0001`, `0012`); the H1 heading uses the un-padded number (e.g., `# 1.`, `# 12.`).
+
+**File naming**: canonical MADR `nnnn-kebab-case-short-title.md` — 4-digit zero-padded sequence, lowercase kebab title, **no** `adr-`/`ADR-` prefix (e.g., `0001-schema-changes-without-migrations.md`).
+
+### Knowledge updates
+
+For each knowledge update:
+1. Read the full target file
+2. Find the appropriate section (match by heading)
+3. Add or update content within that section
+4. If the section does not exist, create it in a logical position
+5. Add a source marker: `<!-- Extracted from specs/<spec-name> on YYYY-MM-DD -->`
+
+### Guidelines updates
+
+Same approach as knowledge updates:
+1. Read the full target file (or create a new one if needed)
+2. Find the appropriate section
+3. Add the prescriptive pattern with code examples where relevant
+4. Add a source marker: `<!-- Extracted from specs/<spec-name> on YYYY-MM-DD -->`
+
+If creating a new guidelines file, follow the standard structure:
+```markdown
+# <Topic> Guidelines
+
+## Overview
+
+<Brief description of what this document covers.>
+
+## <Sections...>
+```
+
+## Phase 4: Cleanup & Report
+
+Perform the following steps for **each spec** that had approved extractions.
+
+### 1. Create extraction record
+
+Write `EXTRACTED.md` in each spec directory:
+
+```markdown
+# Extraction Record
+
+**Extracted on**: <YYYY-MM-DD>
+**Extracted by**: speckit.opsmill.extract
+
+## ADRs Created
+
+- <path to ADR file> (from R#)
+- ...
+
+## Knowledge Updated
+
+- <path to knowledge file> (<section name>)
+- ...
+
+## Guidelines Updated
+
+- <path to guidelines file> (<section name>)
+- ...
+
+## Archive
+
+Spec directory moved to `specs/archive/<spec-name>/` as a historical record.
+```
+
+### 2. Update spec status and archive
+
+For each spec:
+1. In `spec.md`, update or add the status field to: `**Status**: Extracted`
+2. Move the entire spec directory into `specs/archive/`:
+   ```bash
+   mkdir -p specs/archive
+   mv specs/<spec-name> specs/archive/<spec-name>
+   ```
+   This makes it immediately clear which specs have been processed and which are still active.
+
+### 3. Update dev/README.md
+
+After **all** specs have been processed, update `dev/README.md` once with all new files:
+- If any **new** files were created in `dev/knowledge/`, `dev/guidelines/`, or `dev/adr/`:
+  - Read `dev/README.md`
+  - Add new entries to the appropriate section (Current Guidelines, Current Knowledge, or a new Current ADRs section)
+  - Follow the existing link format: `- [filename.md](path/to/filename.md) - Brief description`
+- If `dev/adr/` now has content and there is no "Current ADRs" section in the README, create one following the pattern of the existing sections.
+
+### 4. Report
+
+Print a combined summary covering all processed specs:
+
+```markdown
+## Extraction Complete
+
+**Date**: YYYY-MM-DD
+**Specs processed**: N
+
+### Per-Spec Summary
+
+| Spec | ADRs | Knowledge | Guidelines | Status |
+|------|------|-----------|------------|--------|
+| specs/<spec-name-1> | N | N | N | archived |
+| specs/<spec-name-2> | N | N | N | archived |
+
+### Totals
+- N ADR(s) created in dev/adr/
+- N knowledge file(s) updated
+- N guideline file(s) updated
+
+### Archived
+- specs/<spec-name-1> → specs/archive/<spec-name-1>
+- specs/<spec-name-2> → specs/archive/<spec-name-2>
+
+### Files Created/Modified
+- <list each file path>
+
+### Next Steps
+- Review the created ADRs for accuracy
+- Verify knowledge and guideline updates read well in context
+```
+
+
+## Behavior Rules
+
+- **Never write files without user approval** in Phase 2
+- If analysis finds nothing to extract (empty across all categories), report cleanly: "No extractable content found in this spec." and skip the review phase
+- If a knowledge file section already contains similar content, flag it for user review rather than duplicating
+- Do not reformat or restructure existing content in knowledge/guidelines files beyond the specific additions
+- Always create `specs/archive/` before moving if it does not exist
+- ADR `Source` paths must reference the archive location (`specs/archive/<spec-name>/`) since the spec will be moved there
+- For single quotes in bash args, use escape syntax: e.g. `'I'\''m Groot'` (or double-quote if possible: `"I'm Groot"`)

--- a/.agents/skills/speckit-opsmill-retrospect/SKILL.md
+++ b/.agents/skills/speckit-opsmill-retrospect/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: speckit-opsmill-retrospect
+description: Run a session retrospective that surfaces context-management gaps and
+  routes them to approved follow-up actions.
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: opsmill:commands/retrospect.md
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty). Treat it as optional scope guidance, such as a focus area, a pasted transcript summary, or a preferred disposition.
+
+## Outline
+
+Run a retrospective on the current agent session while the work is still fresh in context. The goal is to identify concrete improvements to the repository's context-management surface area: `AGENTS.md`, `CLAUDE.md`, `.claude/settings.json`, `.agents/skills/`, `.agents/commands/`, `.specify/templates/`, `dev/knowledge/`, `dev/guides/`, `dev/guidelines/`, `dev/adr/`, and product or architecture decisions that caused avoidable friction.
+
+This command closes the loop from "the agent struggled with X" to "X is captured as an approved repo improvement, dedicated PR, GitHub issue, or local-only note."
+
+## Operating Constraints
+
+- Stay read-only until the user approves the report and any disposition buckets. Do not edit files, commit, push, or create GitHub issues before approval.
+- Present the full retrospective before taking action. Ask for explicit approval per disposition bucket: `fix-now`, `open-pr`, `github-issue`, and `local-only`.
+- For `fix-now`, present a diff preview or precise patch plan before writing files. Apply only the approved changes.
+- For `github-issue`, defer to the existing `create-issue` skill when available; if it is unavailable, use `gh issue create` only after the user approves the exact issue content.
+- Respect `AGENTS.md` guardrails. Ask First topics, including database migrations, GraphQL schema changes, new dependencies, CI/CD workflow changes, and authentication or authorization changes, are never auto-applied. Route them to `open-pr` or `github-issue`.
+- Never edit generated files. If a finding points at generated output, identify the source template or generator instead.
+- Do not treat personal preferences as repo policy. Use `local-only` for non-project-specific workflow preferences.
+
+## Phase 1: Resolve Session Context
+
+1. Identify the repository root and current branch:
+   - Run `git rev-parse --show-toplevel`.
+   - Run `git branch --show-current`.
+   - Run `git status --short` to understand whether there are existing edits.
+2. Determine whether the session is inside an active spec-kit feature:
+   - Try `.specify/scripts/bash/check-prerequisites.sh --json --paths-only`.
+   - If it succeeds, record `FEATURE_DIR` and use `FEATURE_DIR/retrospective.md` as the report path.
+   - If it fails or the project is not on a spec-kit feature branch, continue as an ad-hoc session and use `.claude/retrospectives/YYYYMMDD-HHMMSS-<short-branch-or-session-slug>.md` as the report path.
+3. Load only the context needed to classify findings:
+   - Root `AGENTS.md` and any area-specific `AGENTS.md` touched this session.
+   - `CLAUDE.md` and `.claude/settings.json` if present.
+   - Relevant skill prompts in `.agents/skills/` and commands in `.agents/commands/`.
+   - Relevant spec-kit templates in `.specify/templates/`.
+   - Relevant `dev/knowledge/`, `dev/guides/`, `dev/guidelines/`, or `dev/adr/` pages.
+   - Current diff and recent commands from the conversation context.
+
+## Phase 2: Identify Findings
+
+Review the current conversation and repository context for friction that was avoidable through better shared context. Organize findings into exactly these categories:
+
+1. **Instructions / Configuration Gaps**
+   - Missing, unclear, duplicated, or contradictory guidance in `AGENTS.md`, `CLAUDE.md`, `.claude/settings.json`, skill prompts, commands, or spec-kit templates.
+   - Required repo workflows that the agent had to infer or rediscover.
+2. **Documentation Gaps**
+   - Missing or stale content in `dev/knowledge/`, `dev/guides/`, `dev/guidelines/`, or `dev/adr/`.
+   - Docs that contradicted current code or left out required verification steps.
+3. **Architectural Friction**
+   - Product, architecture, or code choices that forced repeated workarounds.
+   - Candidates for ADRs, refactors, or product follow-up.
+4. **Mistakes & Corrections**
+   - Wrong turns taken during the session.
+   - The guardrail, instruction, template change, or test that would have prevented the mistake.
+
+Prefer concrete findings over broad observations. Each finding must cite the session event or repository location that motivated it.
+
+## Phase 3: Assign Dispositions
+
+For each finding, propose one disposition:
+
+| Disposition | Use When | Action After Approval |
+|-------------|----------|-----------------------|
+| `fix-now` | Small, low-risk repo context updates that belong on the current branch and do not touch Ask First topics. | Show diff preview, then edit files only after approval. |
+| `open-pr` | Context or harness changes that should be reviewed separately from the current feature branch, or anything touching Ask First topics. | Draft a branch/PR plan. Do not branch, commit, push, or open a PR unless explicitly approved. |
+| `github-issue` | Larger work, ambiguous ownership, product/architecture debt, ADR candidates needing human authorship, or work outside current scope. | Use the `create-issue` skill to draft each issue; create only after approval. |
+| `local-only` | Personal workflow preferences or notes that should not become repo policy. | Record only in approved local .specify/memory/report locations supported by the runtime. |
+
+Disposition rules:
+
+- If a finding involves database schema or migration changes, GraphQL schema changes, new dependencies, CI/CD workflows, authentication, authorization, or generated files, do not assign `fix-now`.
+- If a finding needs product or architecture ownership, prefer `github-issue` unless the user explicitly asks for a dedicated PR.
+- If a finding is already fully covered by existing docs or instructions, do not include it as a finding; mention it only in a brief "No action" note if helpful.
+
+## Phase 4: Produce Review Report
+
+Before writing any files, present the retrospective in chat using this structure:
+
+```markdown
+## Session Retrospective
+
+**Scope**: <current feature, branch, or ad-hoc session>
+**Proposed report path**: <path>
+
+### Findings
+
+| ID | Category | Evidence | Improvement | Disposition |
+|----|----------|----------|-------------|-------------|
+| R1 | Instructions / Configuration Gaps | <specific session event or file path> | <concrete change> | fix-now |
+
+### Disposition Buckets
+
+#### fix-now
+
+- R1: <target file and change summary>
+
+#### open-pr
+
+- R2: <branch or PR scope>
+
+#### github-issue
+
+- R3: <issue title>
+
+#### local-only
+
+- R4: <memory/report note>
+
+### Approval Request
+
+Reply with one or more approved buckets, for example:
+
+- `approve report only`
+- `approve fix-now`
+- `approve github-issue R3`
+- `approve all except open-pr`
+```
+
+The report must include concrete findings in all four categories. If a category genuinely has no findings, include the category with `None found` and a one-sentence reason.
+
+## Phase 5: Save Report
+
+Save the retrospective report only after the user approves `report only`, a disposition bucket, or `all`.
+
+Report path:
+
+- Active spec-kit feature: `specs/<current-feature>/retrospective.md`.
+- Ad-hoc session: `.claude/retrospectives/YYYYMMDD-HHMMSS-<short-branch-or-session-slug>.md`.
+
+If the report path already exists, append a numeric suffix rather than overwriting it.
+
+## Phase 6: Execute Approved Dispositions
+
+Process only the buckets the user approved.
+
+### fix-now
+
+1. Show a diff preview or exact patch plan for the approved findings.
+2. Wait for confirmation if the preview changes the original scope.
+3. Apply edits with normal repository editing rules.
+4. Run relevant validation. For prompt, command, and Markdown-only changes, at minimum verify paths exist and the command can be discovered from the extension manifest and runtime command file. Run broader lint or tests when touched files are covered by existing automation.
+
+### open-pr
+
+1. Draft the proposed branch name, PR title, PR body summary, and changed file list.
+2. Ask for explicit approval before creating a branch, committing, pushing, or opening a PR.
+3. If approved, use the repository's normal PR workflow.
+
+### github-issue
+
+1. For each approved finding, invoke the `create-issue` skill with the finding as source material.
+2. Present the exact issue title/body/labels for approval.
+3. Create issues only after approval.
+
+### local-only
+
+1. Record the note only in runtime-supported local memory or in the approved retrospective report.
+2. Do not add local-only preferences to repo files unless the user explicitly reclassifies them as repo policy.
+
+## Completion
+
+After approved actions are complete, provide a brief summary:
+
+- Report path
+- Actions taken
+- Validation run
+- Any remaining unapproved buckets

--- a/.agents/skills/speckit-opsmill-summary/SKILL.md
+++ b/.agents/skills/speckit-opsmill-summary/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: speckit-opsmill-summary
+description: Produce a flow-level summary of the current Claude Code session — executive
+  summary, chronological timeline, and outcomes — written into the active feature
+  directory next to spec.md / plan.md.
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: opsmill:commands/summary.md
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+Supported argument: `--since <commit|time>` to bound the summary window.
+Examples:
+
+- `--since HEAD~10` — limit the timeline to phases that began after the
+  10th-most-recent commit on this branch.
+- `--since 14:00` — only include phases that occurred after 2 PM local time
+  in the active session.
+
+If no argument is given, summarize the **entire live session**.
+
+## Goal
+
+Produce a single markdown document that lets a teammate (or future-you)
+understand the *flow* of the session in under 60 seconds. The unit of
+output is the working session, not any one artifact. Different
+granularity from `speckit.archive` (per-feature, permanent) and
+`speckit.reconcile.run` (drift-fixing).
+
+## Operating Constraints
+
+**STAY AT THE FLOW LEVEL.** This summary is a narrative, not a
+transcript. Do **NOT** include any of the following:
+
+- Per-tool-call narration ("called Read on X.py, then called Edit on...")
+- Diffs or hunks of any size
+- Line numbers
+- Code snippets longer than a single line
+- File-by-file change logs (those belong in PR descriptions and `git log`)
+- Step-by-step reproductions of debugging
+- Quotes from the conversation buffer longer than one short clause
+
+**STRICTLY ADDITIVE.** Do not modify `spec.md`, `plan.md`, `tasks.md`,
+or any source files. The only file this command writes is the session
+summary itself.
+
+**IDEMPOTENT IN SPIRIT.** A second invocation in the same session must
+produce a comparable summary, not a summary of summaries. Ignore
+previously generated session files when composing the new one.
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` from repo root and parse `FEATURE_DIR` from the JSON
+   output. All paths must be absolute.
+
+   - If `FEATURE_DIR` is missing, empty, or the resolved directory does
+     not exist, **fail fast** with a clear error such as:
+     `No feature directory resolved from current branch — /speckit.opsmill.summary requires an active feature branch.`
+     Suggest the user switch to a feature branch and re-run.
+
+2. Parse `$ARGUMENTS` for an optional `--since <value>`. Treat the
+   value as opaque — pass it through to `git log --since=<value>` if it
+   parses as a date/time, otherwise treat it as a git revision and use
+   `git log <value>..HEAD`. Do not attempt to interpret it any further.
+
+3. **Gather context** for the summary, in this order of preference:
+
+   a. The live conversation context (primary source — the actual
+      session is what is being summarized).
+   b. `git log` on the current branch, optionally bounded by `--since`,
+      for outcomes that already landed as commits.
+   c. `FEATURE_DIR/spec.md`, `plan.md`, `tasks.md` if they exist — only
+      to anchor terminology, not to copy content.
+
+   Do **not** read every changed file. Do **not** generate diffs. Stay
+   at the level of "what phase of work was happening, and what did it
+   produce".
+
+4. **Compose the summary** with exactly these three sections, in this
+   order:
+
+   ### Executive Summary
+
+   One paragraph (2–4 sentences). What was this session about? What was
+   the working theme? Reading just this paragraph should answer "what
+   did they spend their time on today?".
+
+   ### Timeline
+
+   A chronological bullet list. Each entry is a single short line in
+   the form `HH:MM — <human-readable phase>`, e.g.:
+
+   - `10:42 — investigated failing E2E test in deployments_create.py`
+   - `11:05 — narrowed cause to driver init order`
+   - `11:30 — applied fix and re-ran suite`
+
+   Aim for 5–15 entries. Collapse near-duplicate phases (e.g. three
+   consecutive "ran tests" lines into one). If exact timestamps are not
+   recoverable, use relative ordering with no `HH:MM` prefix and a
+   leading dash only.
+
+   ### Outcomes
+
+   A short bullet list of concrete results from the session. Reference
+   paths and PRs only — no diffs. Examples:
+
+   - Opened PR #161 (speckit-extensions cleanup).
+   - Materially changed `.specify/extensions/auto/`, `tinyspec/`.
+   - Decided: extensions invoke skills, not slash commands.
+   - Deferred: rewriting the auto extension's hook condition DSL.
+
+5. **Write the file.**
+
+   - Path: `FEATURE_DIR/sessions/session-YYYY-MM-DD-HHMM.md`, where
+     `YYYY-MM-DD-HHMM` is the local time at invocation.
+   - Create `FEATURE_DIR/sessions/` if it does not exist.
+   - If a file with the same `HHMM` already exists, append a numeric
+     suffix (`-2`, `-3`, …) rather than overwriting.
+
+6. **Print the resolved path** back to the user as the final message,
+   plus a one-line reminder that the summary is intentionally
+   high-level and the conversation transcript / `git log` remain the
+   sources of truth for detail.
+
+## Quality Bar
+
+A reader who was not in the session should, after under 60 seconds with
+the document, be able to answer:
+
+- What was the session trying to accomplish?
+- What was the rough order of work?
+- What concretely shipped, what was decided, what was deferred?
+
+If the draft cannot pass that bar, tighten it before writing. If it
+exceeds ~80 lines of markdown, you are too detailed — cut.

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ __pycache__
 .claude
 **/worktrees
 .token-savior-cache.json
+
+# Speckit local feature pointer
+.specify/feature.json

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -17,6 +17,14 @@ hooks:
     prompt: Run PR review on implemented changes?
     description: Comprehensive review after implementation
     condition: null
+  - extension: opsmill
+    command: speckit.opsmill.extract
+    enabled: true
+    optional: true
+    prompt: Extract knowledge, guidelines, and ADRs from the completed spec?
+    description: Promote durable content into dev/knowledge, dev/guidelines, dev/adr
+      before the spec ages out.
+    condition: null
   before_constitution:
   - extension: git
     command: speckit.git.initialize
@@ -166,4 +174,12 @@ hooks:
     optional: true
     prompt: Commit after syncing issues?
     description: Auto-commit after tasks-to-issues conversion
+    condition: null
+  - extension: opsmill
+    command: speckit.opsmill.summary
+    enabled: true
+    optional: true
+    prompt: Produce a session summary in the feature directory?
+    description: Flow-level timeline next to spec.md/plan.md, capturing the handoff
+      to the issue tracker.
     condition: null

--- a/.specify/extensions/.registry
+++ b/.specify/extensions/.registry
@@ -373,6 +373,37 @@
       },
       "registered_skills": [],
       "installed_at": "2026-05-02T14:49:35.534746+00:00"
+    },
+    "opsmill": {
+      "version": "1.0.0",
+      "source": "local",
+      "manifest_hash": "sha256:1728f48f4f44275cb5b96b4bc1b322f323ccc4ad7e50511db61f0e963fea7bfb",
+      "enabled": true,
+      "priority": 10,
+      "registered_commands": {
+        "agy": [
+          "speckit.opsmill.extract",
+          "speckit.opsmill.retrospect",
+          "speckit.opsmill.summary"
+        ],
+        "amp": [
+          "speckit.opsmill.extract",
+          "speckit.opsmill.retrospect",
+          "speckit.opsmill.summary"
+        ],
+        "claude": [
+          "speckit.opsmill.extract",
+          "speckit.opsmill.retrospect",
+          "speckit.opsmill.summary"
+        ],
+        "codex": [
+          "speckit.opsmill.extract",
+          "speckit.opsmill.retrospect",
+          "speckit.opsmill.summary"
+        ]
+      },
+      "registered_skills": [],
+      "installed_at": "2026-06-15T08:41:37.441100+00:00"
     }
   }
 }

--- a/.specify/extensions/opsmill/CHANGELOG.md
+++ b/.specify/extensions/opsmill/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog — extension `opsmill`
+
+Release history for the `opsmill` spec-kit extension (`extension.yml`).
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this artifact adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-05-11
+
+### Added
+- Initial release. Single spec-kit extension (`id: opsmill`,
+  `schema_version: "1.0"`, `requires.speckit_version: ">=0.8.0"`) providing:
+  - `speckit.opsmill.extract` — knowledge / guidelines / ADR extraction
+    from completed spec directories.
+  - `speckit.opsmill.retrospect` — session retrospective with
+    user-approved disposition routing.
+  - `speckit.opsmill.summary` — flow-level session summary in the
+    active feature directory.
+- `requires.scripts: ["check-prerequisites.sh"]` declared (script is shipped
+  by spec-kit core; not vendored here).
+- Two opt-in hooks declared in `extension.yml` so the commands auto-prompt
+  during the SDD flow:
+  - `after_implement` → `speckit.opsmill.extract`
+  - `after_taskstoissues` → `speckit.opsmill.summary`
+  Both `optional: true`; users are prompted before each fires.
+
+### Provenance
+Command bodies are lifted from `opsmill/styrmin/.specify/extensions/`:
+- `commands/extract.md` from `extract/commands/extract.md`. Single edit:
+  line 255 self-reference `speckit.extract` rewritten to
+  `speckit.opsmill.extract`.
+- `commands/retrospect.md` from `retrospect/commands/retrospect.md`.
+  Verbatim, no edits.
+- `commands/summary.md` from `summary/commands/run.md` (renamed). Single
+  edit: line 62 self-reference `/speckit.summary.run` rewritten to
+  `/speckit.opsmill.summary`.
+
+## Smoke test — 2026-05-11T18:05:00Z
+
+- ZIP install: PASS — Created `/tmp/opsmill-speckit-smoke/opsmill-speckit-v1.0.0.zip` from committed HEAD; contents verified (1185 bytes extension.yml, all three command files).
+- Three commands discovered: PASS — `specify extension list` output shows "OpsMill Speckit Workflow (v1.0.0)" with 3 commands enabled:
+  - `speckit.opsmill.extract` — Extract knowledge, guidelines, and ADRs from completed spec directories into the project documentation system.
+  - `speckit.opsmill.retrospect` — Run a session retrospective that surfaces context-management gaps and routes them to approved follow-up actions.
+  - `speckit.opsmill.summary` — Produce a flow-level timeline of the current Claude Code session in the active feature directory.
+- Discovery command used: `specify extension list`
+- Command files verified in scratch project at `.specify/extensions/opsmill/commands/{extract,retrospect,summary}.md`.

--- a/.specify/extensions/opsmill/LICENSE
+++ b/.specify/extensions/opsmill/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.specify/extensions/opsmill/LICENSE
+++ b/.specify/extensions/opsmill/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 OpsMill SAS
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/.specify/extensions/opsmill/README.md
+++ b/.specify/extensions/opsmill/README.md
@@ -1,0 +1,142 @@
+# opsmill-speckit
+
+OpsMill house [spec-kit](https://github.com/github/spec-kit) repo. Ships two
+independently installable artifacts:
+
+1. **Extension `opsmill`** — three workflow commands under the `opsmill`
+   namespace:
+   - `/speckit.opsmill.extract` — extract durable knowledge, guidelines, and
+     ADRs from completed spec directories into `dev/knowledge/`,
+     `dev/guidelines/`, `dev/adr/`.
+   - `/speckit.opsmill.retrospect` — run a session retrospective that surfaces
+     context-management gaps and routes them to `fix-now`, `open-pr`,
+     `github-issue`, or `local-only` dispositions.
+   - `/speckit.opsmill.summary` — produce a flow-level timeline of the current
+     Claude Code session next to `spec.md` / `plan.md` in the active feature
+     directory.
+
+2. **Presets** — drop-in overrides for native spec-kit commands. Each preset
+   is installed independently of the extension. Currently one ships:
+   - [`taskstoissues-jira`](presets/taskstoissues-jira/README.md) — overrides
+     `/speckit.taskstoissues` with a Jira-flavored implementation that fans
+     `tasks.md` out into Jira issues under a single Epic (one issue per
+     `## Phase N:` block) via the Atlassian MCP.
+
+## Requires
+
+- spec-kit `>=0.8.0`
+- `check-prerequisites.sh` (shipped by spec-kit core; present at
+  `.specify/scripts/bash/check-prerequisites.sh` in any spec-kit-initialized
+  repo). Used by the `summary` command via the `{SCRIPT}` placeholder.
+
+## Install
+
+Latest `main`:
+
+```bash
+specify extension add opsmill \
+  --from https://github.com/opsmill/opsmill-speckit/archive/refs/heads/main.zip
+```
+
+Pinned release:
+
+```bash
+specify extension add opsmill \
+  --from https://github.com/opsmill/opsmill-speckit/archive/refs/tags/v1.0.0.zip
+```
+
+Local development install (from a working tree):
+
+```bash
+specify extension add --dev /path/to/opsmill-speckit
+```
+
+## Commands
+
+### `/speckit.opsmill.extract`
+
+Analyzes one or more completed spec directories and extracts durable knowledge
+into the project's documentation system (`dev/knowledge/`, `dev/guidelines/`,
+`dev/adr/`), then marks each spec as extracted.
+
+Accepts multiple specs as space-separated arguments and processes them
+sequentially.
+
+### `/speckit.opsmill.retrospect`
+
+Runs a retrospective on the current agent session while the work is still
+fresh in context. Identifies concrete improvements to the repository's
+context-management surface area (`AGENTS.md`, `CLAUDE.md`,
+`.claude/settings.json`, `.agents/skills/`, `.agents/commands/`,
+`.specify/templates/`, `dev/knowledge/`, `dev/guides/`, `dev/guidelines/`,
+`dev/adr/`) and routes them through user-approved dispositions.
+
+Stays read-only until the user approves each disposition bucket.
+
+### `/speckit.opsmill.summary`
+
+Produces a flow-level summary of the current Claude Code session — executive
+summary, chronological timeline, and outcomes — written into the active
+feature directory next to `spec.md` / `plan.md`.
+
+Supports `--since <commit|time>` to bound the summary window.
+
+### `/speckit.taskstoissues` (preset override)
+
+Provided by the [`taskstoissues-jira`](presets/taskstoissues-jira/README.md)
+preset, not the extension. Install separately:
+
+```bash
+specify preset add taskstoissues-jira \
+  --from https://github.com/opsmill/opsmill-speckit/archive/refs/heads/main.zip \
+  --subdir presets/taskstoissues-jira
+```
+
+See [`presets/taskstoissues-jira/README.md`](presets/taskstoissues-jira/README.md)
+for config (`dev/jira.yml`) and failure-mode details.
+
+## Hooks (auto-fire during SDD)
+
+The extension registers two opt-in hooks at install time. Each prompts before
+running (`optional: true`):
+
+| Event | Command | Purpose |
+|---|---|---|
+| `after_implement` | `/speckit.opsmill.extract` | Promote durable knowledge / guidelines / ADRs out of the just-completed spec. |
+| `after_taskstoissues` | `/speckit.opsmill.summary` | Capture the session timeline at the moment of handoff to the issue tracker. |
+
+`/speckit.opsmill.retrospect` is not wired by default — it remains a manual
+command for interactive session reflection.
+
+The `extension.yml` `hooks:` schema accepts one command per event. To fire
+additional commands at the same event, append entries to your repo's
+`.specify/extensions.yml` registry. Example: also fire `summary` at
+`after_implement`:
+
+```yaml
+# .specify/extensions.yml (consumer-side, snippet)
+hooks:
+  after_implement:
+    - extension: opsmill
+      command: speckit.opsmill.summary
+      enabled: true
+      optional: true
+      prompt: "Produce a session summary in the feature directory?"
+```
+
+## Provenance
+
+Command bodies in v1 are verbatim lifts from
+`opsmill/styrmin/.specify/extensions/`:
+
+- `commands/extract.md` ← `extract/commands/extract.md`
+- `commands/retrospect.md` ← `retrospect/commands/retrospect.md`
+- `commands/summary.md` ← `summary/commands/run.md`
+
+Two surgical line edits update self-references to the namespaced form
+(`speckit.opsmill.<cmd>`); no other content changes. See `CHANGELOG.md`
+for the exact lines.
+
+## License
+
+Apache-2.0. See `LICENSE`.

--- a/.specify/extensions/opsmill/commands/extract.md
+++ b/.specify/extensions/opsmill/commands/extract.md
@@ -1,0 +1,340 @@
+---
+description: Extract knowledge, guidelines, and ADRs from one or more completed spec directories into the project documentation system.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+Goal: Analyze one or more completed spec directories and extract durable knowledge into the project's documentation system (`dev/knowledge/`, `dev/guidelines/`, `dev/adr/`), then mark each spec as extracted.
+
+This command accepts multiple specs as input (space-separated) and processes them sequentially. It operationalizes the documentation lifecycle: `specs/ → knowledge/ or guidelines/` (see `dev/guidelines/markdown.md`).
+
+## Phase 0: Setup & Validation
+
+<thinking>
+First, resolve all spec directories from the user's arguments and validate each one contains the expected artifacts.
+</thinking>
+
+1. **Parse arguments** — split `$ARGUMENTS` into individual spec identifiers (space-separated). If `$ARGUMENTS` is empty, list available spec directories and ask the user to pick one or more.
+
+2. **Resolve each spec directory**:
+   - For each identifier in the arguments:
+     - If it matches `specs/NNN-*` or `NNN-*`, resolve to `REPO_ROOT/specs/NNN-*`
+     - If it is a bare name like `graphql-name-lookup`, search `specs/` for a matching directory
+     - If no match found for an identifier, report it and continue resolving the rest
+   - If **no** identifiers could be resolved, list available spec directories and ask the user to pick
+
+3. **Validate each resolved spec**:
+   - `spec.md` MUST exist — skip that spec with an error if missing
+   - `research.md` SHOULD exist — warn if missing ("No ADRs can be extracted without research.md") but continue
+
+4. **Check extraction status** for each spec:
+   - If `EXTRACTED.md` exists in the spec directory, warn the user that this spec was previously extracted
+   - Also check if the spec already lives under `specs/archive/` — if so, it was previously extracted and archived
+   - Ask for confirmation before re-extracting — default is abort
+   - The user can choose to skip individual specs from the batch
+
+5. **Summarize resolved specs** — before proceeding, print the list of specs that will be processed:
+   ```
+   Processing N spec(s):
+   1. specs/<spec-name-1>
+   2. specs/<spec-name-2>
+   ...
+   ```
+
+6. **Load existing documentation index** (once, shared across all specs):
+   - List all files in `dev/knowledge/` (recursively)
+   - List all files in `dev/guidelines/` (recursively)
+   - List all files in `dev/adr/` to determine the next ADR number
+   - Read the first 20 lines of each knowledge and guidelines file to build a topic index (title + overview section)
+
+7. **Load spec artifacts** — for each spec, read all available files from its directory:
+   - `research.md` (primary source for ADRs)
+   - `spec.md` (context, scope decisions)
+   - `data-model.md` (schema changes, new methods — if exists)
+   - All files in `contracts/` (API changes — if exists)
+   - `plan.md` (architectural context — if exists)
+
+## Phase 1: Analysis & Classification
+
+<thinking>
+For each spec, I need to parse each source and classify content into three buckets: ADR, Knowledge, Guideline. I should also identify content to skip with a clear reason. I'll process specs sequentially and tag each finding with its source spec.
+</thinking>
+
+Repeat the following steps for **each resolved spec directory**. Tag every finding with the source spec name so the extraction plan in Phase 2 groups items by spec.
+
+### Step 1: Extract ADR candidates from research.md
+
+Parse each `## R#` section in `research.md`. For each entry:
+
+1. Extract: Decision, Rationale, Alternatives considered, Implementation pattern
+2. Determine if it is ADR-worthy using this heuristic:
+   - **ADR-worthy**: Affects system structure, API contracts, data models, error handling strategy, or establishes a pattern used across multiple components
+   - **Not ADR-worthy**: One-off implementation detail with no broader implications (e.g., a local variable naming choice, a single method signature)
+3. Draft an ADR title (concise, decision-focused — e.g., "Dual identifier resolution via service-layer helpers")
+
+Also scan `spec.md` for scope decisions or trade-offs in the Clarifications or Assumptions sections that represent architectural choices worth recording.
+
+### Step 2: Extract knowledge candidates
+
+Scan for content that describes **how the system works after the feature**:
+
+| Source | What to look for | Target file |
+|--------|-----------------|-------------|
+| `data-model.md` | New entities, fields, relationships, constraints | `dev/knowledge/backend/data-models.md` |
+| `contracts/` | New or changed GraphQL queries, mutations, types | `dev/knowledge/backend/api.md` |
+| `research.md` | New service patterns, architectural patterns | `dev/knowledge/backend/services.md` or relevant file |
+| `spec.md` | New concepts or domain terminology | `dev/knowledge/backend/overview.md` or relevant file |
+
+For each finding, map it to a specific existing knowledge file and section. If no existing file fits, propose a new file with a name following `kebab-case.md` convention.
+
+### Step 3: Extract guideline candidates
+
+Scan `research.md` for implementation patterns that establish **repeatable, prescriptive conventions** for future code:
+
+- New parameter patterns → `dev/guidelines/backend/python.md` or `dev/guidelines/cyclopts.md`
+- New error handling conventions → `dev/guidelines/backend/python.md`
+- New API design conventions → `dev/guidelines/backend/graphql.md` (create if needed)
+- New testing patterns → relevant guidelines file
+
+Only extract patterns that are **prescriptive** (should be followed in future code). Do NOT extract patterns that are merely **descriptive** of how this specific feature works — those belong in knowledge.
+
+### Step 4: Identify skipped content
+
+For each piece of spec content not classified above, note it with a reason:
+- Execution artifacts (`plan.md`, `quickstart.md`) — no durable knowledge
+- Implementation details already captured in code — no need to duplicate
+- One-off decisions with no broader applicability
+
+## Phase 2: Interactive Review
+
+Present findings in a structured extraction plan. When processing multiple specs, group the plan by spec. Use a **global numbering scheme** across all specs so that item numbers are unique (e.g., spec 1 items are 1–4, spec 2 items are 5–8).
+
+Use this format:
+
+```markdown
+## Extraction Plan
+
+### specs/<spec-name-1>
+
+#### ADRs to Create (<count>)
+
+| # | Source | Title | Target File |
+|---|--------|-------|-------------|
+| 1 | R1 | <title> | dev/adr/nnnn-<slug>.md |
+| 2 | R2 | <title> | dev/adr/nnnn-<slug>.md |
+
+#### Knowledge Updates (<count>)
+
+| # | Target File | Section | Change | Summary |
+|---|-------------|---------|--------|---------|
+| 3 | dev/knowledge/backend/api.md | Queries | UPDATE | <what changes> |
+
+#### Guidelines Updates (<count>)
+
+| # | Target File | Section | Change | Summary |
+|---|-------------|---------|--------|---------|
+| 4 | dev/guidelines/backend/python.md | Error Handling | UPDATE | <what changes> |
+
+#### Skipped (with reasons)
+
+| Source | Reason |
+|--------|--------|
+| plan.md | Execution artifact — no durable knowledge |
+
+---
+
+### specs/<spec-name-2>
+
+#### ADRs to Create (<count>)
+
+| # | Source | Title | Target File |
+|---|--------|-------|-------------|
+| 5 | R1 | <title> | dev/adr/nnnn-<slug>.md |
+
+...
+```
+
+When processing a single spec, omit the per-spec grouping headers and use the simpler flat format (same as the multi-spec table structure but without the `### specs/<name>` wrapper).
+
+After presenting, tell the user:
+
+> **Actions:**
+> - `approve all` — proceed with all extractions across all specs
+> - `approve spec <name>` — approve all items for a specific spec
+> - `approve adrs` / `approve knowledge` / `approve guidelines` — approve by category (across all specs)
+> - `skip N` — skip a specific numbered item
+> - `edit N` — modify a specific item before writing
+> - `group N,M` — merge multiple ADR items into a single ADR
+
+Wait for user response before proceeding. Do NOT write any files until the user approves.
+
+## Phase 3: Write Extractions
+
+For each approved item across all specs, write the content. ADR numbering is sequential across all specs (i.e., if spec 1 creates `0005` and `0006`, spec 2 starts at `0007`).
+
+### ADRs
+
+Create new files in `dev/adr/` using this format:
+
+```markdown
+# N. <Title>
+
+**Status**: Accepted
+**Date**: <today's date YYYY-MM-DD>
+**Source**: specs/archive/<spec-name>/research.md (R#)
+
+## Context
+
+<What is the issue that motivates this decision? Derive from the feature context in spec.md and the specific problem the R# entry addresses.>
+
+## Decision
+
+<What was decided. Taken from the Decision field of the R# entry.>
+
+## Consequences
+
+<What becomes easier or harder as a result. Synthesize from the Rationale and any implementation notes.>
+
+## Alternatives Considered
+
+<What other options were evaluated and why they were rejected. Taken from the Alternatives considered field.>
+```
+
+**Numbering**: Read existing files in `dev/adr/` to find the highest existing ADR number. Start new ADRs at the next sequential number. Zero-pad the **filename** sequence to **4 digits** (e.g., `0001`, `0012`); the H1 heading uses the un-padded number (e.g., `# 1.`, `# 12.`).
+
+**File naming**: canonical MADR `nnnn-kebab-case-short-title.md` — 4-digit zero-padded sequence, lowercase kebab title, **no** `adr-`/`ADR-` prefix (e.g., `0001-schema-changes-without-migrations.md`).
+
+### Knowledge updates
+
+For each knowledge update:
+1. Read the full target file
+2. Find the appropriate section (match by heading)
+3. Add or update content within that section
+4. If the section does not exist, create it in a logical position
+5. Add a source marker: `<!-- Extracted from specs/<spec-name> on YYYY-MM-DD -->`
+
+### Guidelines updates
+
+Same approach as knowledge updates:
+1. Read the full target file (or create a new one if needed)
+2. Find the appropriate section
+3. Add the prescriptive pattern with code examples where relevant
+4. Add a source marker: `<!-- Extracted from specs/<spec-name> on YYYY-MM-DD -->`
+
+If creating a new guidelines file, follow the standard structure:
+```markdown
+# <Topic> Guidelines
+
+## Overview
+
+<Brief description of what this document covers.>
+
+## <Sections...>
+```
+
+## Phase 4: Cleanup & Report
+
+Perform the following steps for **each spec** that had approved extractions.
+
+### 1. Create extraction record
+
+Write `EXTRACTED.md` in each spec directory:
+
+```markdown
+# Extraction Record
+
+**Extracted on**: <YYYY-MM-DD>
+**Extracted by**: speckit.opsmill.extract
+
+## ADRs Created
+
+- <path to ADR file> (from R#)
+- ...
+
+## Knowledge Updated
+
+- <path to knowledge file> (<section name>)
+- ...
+
+## Guidelines Updated
+
+- <path to guidelines file> (<section name>)
+- ...
+
+## Archive
+
+Spec directory moved to `specs/archive/<spec-name>/` as a historical record.
+```
+
+### 2. Update spec status and archive
+
+For each spec:
+1. In `spec.md`, update or add the status field to: `**Status**: Extracted`
+2. Move the entire spec directory into `specs/archive/`:
+   ```bash
+   mkdir -p specs/archive
+   mv specs/<spec-name> specs/archive/<spec-name>
+   ```
+   This makes it immediately clear which specs have been processed and which are still active.
+
+### 3. Update dev/README.md
+
+After **all** specs have been processed, update `dev/README.md` once with all new files:
+- If any **new** files were created in `dev/knowledge/`, `dev/guidelines/`, or `dev/adr/`:
+  - Read `dev/README.md`
+  - Add new entries to the appropriate section (Current Guidelines, Current Knowledge, or a new Current ADRs section)
+  - Follow the existing link format: `- [filename.md](path/to/filename.md) - Brief description`
+- If `dev/adr/` now has content and there is no "Current ADRs" section in the README, create one following the pattern of the existing sections.
+
+### 4. Report
+
+Print a combined summary covering all processed specs:
+
+```markdown
+## Extraction Complete
+
+**Date**: YYYY-MM-DD
+**Specs processed**: N
+
+### Per-Spec Summary
+
+| Spec | ADRs | Knowledge | Guidelines | Status |
+|------|------|-----------|------------|--------|
+| specs/<spec-name-1> | N | N | N | archived |
+| specs/<spec-name-2> | N | N | N | archived |
+
+### Totals
+- N ADR(s) created in dev/adr/
+- N knowledge file(s) updated
+- N guideline file(s) updated
+
+### Archived
+- specs/<spec-name-1> → specs/archive/<spec-name-1>
+- specs/<spec-name-2> → specs/archive/<spec-name-2>
+
+### Files Created/Modified
+- <list each file path>
+
+### Next Steps
+- Review the created ADRs for accuracy
+- Verify knowledge and guideline updates read well in context
+```
+
+
+## Behavior Rules
+
+- **Never write files without user approval** in Phase 2
+- If analysis finds nothing to extract (empty across all categories), report cleanly: "No extractable content found in this spec." and skip the review phase
+- If a knowledge file section already contains similar content, flag it for user review rather than duplicating
+- Do not reformat or restructure existing content in knowledge/guidelines files beyond the specific additions
+- Always create `specs/archive/` before moving if it does not exist
+- ADR `Source` paths must reference the archive location (`specs/archive/<spec-name>/`) since the spec will be moved there
+- For single quotes in bash args, use escape syntax: e.g. `'I'\''m Groot'` (or double-quote if possible: `"I'm Groot"`)

--- a/.specify/extensions/opsmill/commands/extract.md
+++ b/.specify/extensions/opsmill/commands/extract.md
@@ -26,7 +26,7 @@ First, resolve all spec directories from the user's arguments and validate each 
 
 2. **Resolve each spec directory**:
    - For each identifier in the arguments:
-     - If it matches `specs/NNN-*` or `NNN-*`, resolve to `REPO_ROOT/specs/NNN-*`
+     - If it matches `specs/NNN-*` or `NNN-*`, resolve to `specs/NNN-*` (relative to the repo root)
      - If it is a bare name like `graphql-name-lookup`, search `specs/` for a matching directory
      - If no match found for an identifier, report it and continue resolving the rest
    - If **no** identifiers could be resolved, list available spec directories and ask the user to pick
@@ -53,7 +53,7 @@ First, resolve all spec directories from the user's arguments and validate each 
    - List all files in `dev/knowledge/` (recursively)
    - List all files in `dev/guidelines/` (recursively)
    - List all files in `dev/adr/` to determine the next ADR number
-   - Read the first 20 lines of each knowledge and guidelines file to build a topic index (title + overview section)
+   - Read each knowledge and guidelines file's H1 title and opening overview section (skip any YAML frontmatter; read past long intros as needed) to build a topic index
 
 7. **Load spec artifacts** — for each spec, read all available files from its directory:
    - `research.md` (primary source for ADRs)
@@ -72,7 +72,7 @@ Repeat the following steps for **each resolved spec directory**. Tag every findi
 
 ### Step 1: Extract ADR candidates from research.md
 
-Parse each `## R#` section in `research.md`. For each entry:
+If `research.md` does not exist for this spec (flagged in Phase 0), skip this step — no ADRs can be extracted from it. Otherwise, parse each `## R#` section in `research.md`. For each entry:
 
 1. Extract: Decision, Rationale, Alternatives considered, Implementation pattern
 2. Determine if it is ADR-worthy using this heuristic:

--- a/.specify/extensions/opsmill/commands/retrospect.md
+++ b/.specify/extensions/opsmill/commands/retrospect.md
@@ -1,0 +1,175 @@
+---
+description: Run a session retrospective that surfaces context-management gaps and routes them to approved follow-up actions.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty). Treat it as optional scope guidance, such as a focus area, a pasted transcript summary, or a preferred disposition.
+
+## Outline
+
+Run a retrospective on the current agent session while the work is still fresh in context. The goal is to identify concrete improvements to the repository's context-management surface area: `AGENTS.md`, `CLAUDE.md`, `.claude/settings.json`, `.agents/skills/`, `.agents/commands/`, `.specify/templates/`, `dev/knowledge/`, `dev/guides/`, `dev/guidelines/`, `dev/adr/`, and product or architecture decisions that caused avoidable friction.
+
+This command closes the loop from "the agent struggled with X" to "X is captured as an approved repo improvement, dedicated PR, GitHub issue, or local-only note."
+
+## Operating Constraints
+
+- Stay read-only until the user approves the report and any disposition buckets. Do not edit files, commit, push, or create GitHub issues before approval.
+- Present the full retrospective before taking action. Ask for explicit approval per disposition bucket: `fix-now`, `open-pr`, `github-issue`, and `local-only`.
+- For `fix-now`, present a diff preview or precise patch plan before writing files. Apply only the approved changes.
+- For `github-issue`, defer to the existing `create-issue` skill when available; if it is unavailable, use `gh issue create` only after the user approves the exact issue content.
+- Respect `AGENTS.md` guardrails. Ask First topics, including database migrations, GraphQL schema changes, new dependencies, CI/CD workflow changes, and authentication or authorization changes, are never auto-applied. Route them to `open-pr` or `github-issue`.
+- Never edit generated files. If a finding points at generated output, identify the source template or generator instead.
+- Do not treat personal preferences as repo policy. Use `local-only` for non-project-specific workflow preferences.
+
+## Phase 1: Resolve Session Context
+
+1. Identify the repository root and current branch:
+   - Run `git rev-parse --show-toplevel`.
+   - Run `git branch --show-current`.
+   - Run `git status --short` to understand whether there are existing edits.
+2. Determine whether the session is inside an active spec-kit feature:
+   - Try `.specify/scripts/bash/check-prerequisites.sh --json --paths-only`.
+   - If it succeeds, record `FEATURE_DIR` and use `FEATURE_DIR/retrospective.md` as the report path.
+   - If it fails or the project is not on a spec-kit feature branch, continue as an ad-hoc session and use `.claude/retrospectives/YYYYMMDD-HHMMSS-<short-branch-or-session-slug>.md` as the report path.
+3. Load only the context needed to classify findings:
+   - Root `AGENTS.md` and any area-specific `AGENTS.md` touched this session.
+   - `CLAUDE.md` and `.claude/settings.json` if present.
+   - Relevant skill prompts in `.agents/skills/` and commands in `.agents/commands/`.
+   - Relevant spec-kit templates in `.specify/templates/`.
+   - Relevant `dev/knowledge/`, `dev/guides/`, `dev/guidelines/`, or `dev/adr/` pages.
+   - Current diff and recent commands from the conversation context.
+
+## Phase 2: Identify Findings
+
+Review the current conversation and repository context for friction that was avoidable through better shared context. Organize findings into exactly these categories:
+
+1. **Instructions / Configuration Gaps**
+   - Missing, unclear, duplicated, or contradictory guidance in `AGENTS.md`, `CLAUDE.md`, `.claude/settings.json`, skill prompts, commands, or spec-kit templates.
+   - Required repo workflows that the agent had to infer or rediscover.
+2. **Documentation Gaps**
+   - Missing or stale content in `dev/knowledge/`, `dev/guides/`, `dev/guidelines/`, or `dev/adr/`.
+   - Docs that contradicted current code or left out required verification steps.
+3. **Architectural Friction**
+   - Product, architecture, or code choices that forced repeated workarounds.
+   - Candidates for ADRs, refactors, or product follow-up.
+4. **Mistakes & Corrections**
+   - Wrong turns taken during the session.
+   - The guardrail, instruction, template change, or test that would have prevented the mistake.
+
+Prefer concrete findings over broad observations. Each finding must cite the session event or repository location that motivated it.
+
+## Phase 3: Assign Dispositions
+
+For each finding, propose one disposition:
+
+| Disposition | Use When | Action After Approval |
+|-------------|----------|-----------------------|
+| `fix-now` | Small, low-risk repo context updates that belong on the current branch and do not touch Ask First topics. | Show diff preview, then edit files only after approval. |
+| `open-pr` | Context or harness changes that should be reviewed separately from the current feature branch, or anything touching Ask First topics. | Draft a branch/PR plan. Do not branch, commit, push, or open a PR unless explicitly approved. |
+| `github-issue` | Larger work, ambiguous ownership, product/architecture debt, ADR candidates needing human authorship, or work outside current scope. | Use the `create-issue` skill to draft each issue; create only after approval. |
+| `local-only` | Personal workflow preferences or notes that should not become repo policy. | Record only in approved local memory/report locations supported by the runtime. |
+
+Disposition rules:
+
+- If a finding involves database schema or migration changes, GraphQL schema changes, new dependencies, CI/CD workflows, authentication, authorization, or generated files, do not assign `fix-now`.
+- If a finding needs product or architecture ownership, prefer `github-issue` unless the user explicitly asks for a dedicated PR.
+- If a finding is already fully covered by existing docs or instructions, do not include it as a finding; mention it only in a brief "No action" note if helpful.
+
+## Phase 4: Produce Review Report
+
+Before writing any files, present the retrospective in chat using this structure:
+
+```markdown
+## Session Retrospective
+
+**Scope**: <current feature, branch, or ad-hoc session>
+**Proposed report path**: <path>
+
+### Findings
+
+| ID | Category | Evidence | Improvement | Disposition |
+|----|----------|----------|-------------|-------------|
+| R1 | Instructions / Configuration Gaps | <specific session event or file path> | <concrete change> | fix-now |
+
+### Disposition Buckets
+
+#### fix-now
+
+- R1: <target file and change summary>
+
+#### open-pr
+
+- R2: <branch or PR scope>
+
+#### github-issue
+
+- R3: <issue title>
+
+#### local-only
+
+- R4: <memory/report note>
+
+### Approval Request
+
+Reply with one or more approved buckets, for example:
+
+- `approve report only`
+- `approve fix-now`
+- `approve github-issue R3`
+- `approve all except open-pr`
+```
+
+The report must include concrete findings in all four categories. If a category genuinely has no findings, include the category with `None found` and a one-sentence reason.
+
+## Phase 5: Save Report
+
+Save the retrospective report only after the user approves `report only`, a disposition bucket, or `all`.
+
+Report path:
+
+- Active spec-kit feature: `specs/<current-feature>/retrospective.md`.
+- Ad-hoc session: `.claude/retrospectives/YYYYMMDD-HHMMSS-<short-branch-or-session-slug>.md`.
+
+If the report path already exists, append a numeric suffix rather than overwriting it.
+
+## Phase 6: Execute Approved Dispositions
+
+Process only the buckets the user approved.
+
+### fix-now
+
+1. Show a diff preview or exact patch plan for the approved findings.
+2. Wait for confirmation if the preview changes the original scope.
+3. Apply edits with normal repository editing rules.
+4. Run relevant validation. For prompt, command, and Markdown-only changes, at minimum verify paths exist and the command can be discovered from the extension manifest and runtime command file. Run broader lint or tests when touched files are covered by existing automation.
+
+### open-pr
+
+1. Draft the proposed branch name, PR title, PR body summary, and changed file list.
+2. Ask for explicit approval before creating a branch, committing, pushing, or opening a PR.
+3. If approved, use the repository's normal PR workflow.
+
+### github-issue
+
+1. For each approved finding, invoke the `create-issue` skill with the finding as source material.
+2. Present the exact issue title/body/labels for approval.
+3. Create issues only after approval.
+
+### local-only
+
+1. Record the note only in runtime-supported local memory or in the approved retrospective report.
+2. Do not add local-only preferences to repo files unless the user explicitly reclassifies them as repo policy.
+
+## Completion
+
+After approved actions are complete, provide a brief summary:
+
+- Report path
+- Actions taken
+- Validation run
+- Any remaining unapproved buckets

--- a/.specify/extensions/opsmill/commands/summary.md
+++ b/.specify/extensions/opsmill/commands/summary.md
@@ -1,8 +1,8 @@
 ---
 description: Produce a flow-level summary of the current Claude Code session — executive summary, chronological timeline, and outcomes — written into the active feature directory next to spec.md / plan.md.
 scripts:
-  sh: scripts/bash/check-prerequisites.sh --json --paths-only
-  ps: scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly
+  sh: ../../scripts/bash/check-prerequisites.sh --json --paths-only
+  ps: ../../scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly
 ---
 
 ## User Input

--- a/.specify/extensions/opsmill/commands/summary.md
+++ b/.specify/extensions/opsmill/commands/summary.md
@@ -1,0 +1,139 @@
+---
+description: Produce a flow-level summary of the current Claude Code session — executive summary, chronological timeline, and outcomes — written into the active feature directory next to spec.md / plan.md.
+scripts:
+  sh: scripts/bash/check-prerequisites.sh --json --paths-only
+  ps: scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+Supported argument: `--since <commit|time>` to bound the summary window.
+Examples:
+
+- `--since HEAD~10` — limit the timeline to phases that began after the
+  10th-most-recent commit on this branch.
+- `--since 14:00` — only include phases that occurred after 2 PM local time
+  in the active session.
+
+If no argument is given, summarize the **entire live session**.
+
+## Goal
+
+Produce a single markdown document that lets a teammate (or future-you)
+understand the *flow* of the session in under 60 seconds. The unit of
+output is the working session, not any one artifact. Different
+granularity from `speckit.archive` (per-feature, permanent) and
+`speckit.reconcile.run` (drift-fixing).
+
+## Operating Constraints
+
+**STAY AT THE FLOW LEVEL.** This summary is a narrative, not a
+transcript. Do **NOT** include any of the following:
+
+- Per-tool-call narration ("called Read on X.py, then called Edit on...")
+- Diffs or hunks of any size
+- Line numbers
+- Code snippets longer than a single line
+- File-by-file change logs (those belong in PR descriptions and `git log`)
+- Step-by-step reproductions of debugging
+- Quotes from the conversation buffer longer than one short clause
+
+**STRICTLY ADDITIVE.** Do not modify `spec.md`, `plan.md`, `tasks.md`,
+or any source files. The only file this command writes is the session
+summary itself.
+
+**IDEMPOTENT IN SPIRIT.** A second invocation in the same session must
+produce a comparable summary, not a summary of summaries. Ignore
+previously generated session files when composing the new one.
+
+## Outline
+
+1. Run `{SCRIPT}` from repo root and parse `FEATURE_DIR` from the JSON
+   output. All paths must be absolute.
+
+   - If `FEATURE_DIR` is missing, empty, or the resolved directory does
+     not exist, **fail fast** with a clear error such as:
+     `No feature directory resolved from current branch — /speckit.opsmill.summary requires an active feature branch.`
+     Suggest the user switch to a feature branch and re-run.
+
+2. Parse `$ARGUMENTS` for an optional `--since <value>`. Treat the
+   value as opaque — pass it through to `git log --since=<value>` if it
+   parses as a date/time, otherwise treat it as a git revision and use
+   `git log <value>..HEAD`. Do not attempt to interpret it any further.
+
+3. **Gather context** for the summary, in this order of preference:
+
+   a. The live conversation context (primary source — the actual
+      session is what is being summarized).
+   b. `git log` on the current branch, optionally bounded by `--since`,
+      for outcomes that already landed as commits.
+   c. `FEATURE_DIR/spec.md`, `plan.md`, `tasks.md` if they exist — only
+      to anchor terminology, not to copy content.
+
+   Do **not** read every changed file. Do **not** generate diffs. Stay
+   at the level of "what phase of work was happening, and what did it
+   produce".
+
+4. **Compose the summary** with exactly these three sections, in this
+   order:
+
+   ### Executive Summary
+
+   One paragraph (2–4 sentences). What was this session about? What was
+   the working theme? Reading just this paragraph should answer "what
+   did they spend their time on today?".
+
+   ### Timeline
+
+   A chronological bullet list. Each entry is a single short line in
+   the form `HH:MM — <human-readable phase>`, e.g.:
+
+   - `10:42 — investigated failing E2E test in deployments_create.py`
+   - `11:05 — narrowed cause to driver init order`
+   - `11:30 — applied fix and re-ran suite`
+
+   Aim for 5–15 entries. Collapse near-duplicate phases (e.g. three
+   consecutive "ran tests" lines into one). If exact timestamps are not
+   recoverable, use relative ordering with no `HH:MM` prefix and a
+   leading dash only.
+
+   ### Outcomes
+
+   A short bullet list of concrete results from the session. Reference
+   paths and PRs only — no diffs. Examples:
+
+   - Opened PR #161 (speckit-extensions cleanup).
+   - Materially changed `.specify/extensions/auto/`, `tinyspec/`.
+   - Decided: extensions invoke skills, not slash commands.
+   - Deferred: rewriting the auto extension's hook condition DSL.
+
+5. **Write the file.**
+
+   - Path: `FEATURE_DIR/sessions/session-YYYY-MM-DD-HHMM.md`, where
+     `YYYY-MM-DD-HHMM` is the local time at invocation.
+   - Create `FEATURE_DIR/sessions/` if it does not exist.
+   - If a file with the same `HHMM` already exists, append a numeric
+     suffix (`-2`, `-3`, …) rather than overwriting.
+
+6. **Print the resolved path** back to the user as the final message,
+   plus a one-line reminder that the summary is intentionally
+   high-level and the conversation transcript / `git log` remain the
+   sources of truth for detail.
+
+## Quality Bar
+
+A reader who was not in the session should, after under 60 seconds with
+the document, be able to answer:
+
+- What was the session trying to accomplish?
+- What was the rough order of work?
+- What concretely shipped, what was decided, what was deferred?
+
+If the draft cannot pass that bar, tighten it before writing. If it
+exceeds ~80 lines of markdown, you are too detailed — cut.

--- a/.specify/extensions/opsmill/extension.yml
+++ b/.specify/extensions/opsmill/extension.yml
@@ -1,0 +1,47 @@
+schema_version: "1.0"
+
+extension:
+  id: "opsmill"
+  name: "OpsMill Speckit Workflow"
+  version: "1.0.0"
+  description: "OpsMill house spec-kit commands: knowledge extraction, session retrospective, and session summary."
+  author: "opsmill"
+  repository: "https://github.com/opsmill/opsmill-speckit"
+  license: "Apache-2.0"
+  homepage: "https://github.com/opsmill/opsmill-speckit"
+
+requires:
+  speckit_version: ">=0.8.0"
+  scripts:
+    - "check-prerequisites.sh"
+
+provides:
+  commands:
+    - name: "speckit.opsmill.extract"
+      file: "commands/extract.md"
+      description: "Extract knowledge, guidelines, and ADRs from completed spec directories into the project documentation system."
+    - name: "speckit.opsmill.retrospect"
+      file: "commands/retrospect.md"
+      description: "Run a session retrospective that surfaces context-management gaps and routes them to approved follow-up actions."
+    - name: "speckit.opsmill.summary"
+      file: "commands/summary.md"
+      description: "Produce a flow-level timeline of the current Claude Code session in the active feature directory."
+
+hooks:
+  after_implement:
+    command: "speckit.opsmill.extract"
+    optional: true
+    prompt: "Extract knowledge, guidelines, and ADRs from the completed spec?"
+    description: "Promote durable content into dev/knowledge, dev/guidelines, dev/adr before the spec ages out."
+  after_taskstoissues:
+    command: "speckit.opsmill.summary"
+    optional: true
+    prompt: "Produce a session summary in the feature directory?"
+    description: "Flow-level timeline next to spec.md/plan.md, capturing the handoff to the issue tracker."
+
+tags:
+  - "opsmill"
+  - "extract"
+  - "retrospect"
+  - "summary"
+  - "workflow"

--- a/.specify/extensions/opsmill/presets/CHANGELOG.md
+++ b/.specify/extensions/opsmill/presets/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog — preset collection
+
+Release history for the `presets/` directory, taken as a unit.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this collection adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-05-20
+
+### Added
+- **`taskstoissues-jira`** (preset version `1.0.0`) — initial release of
+  the collection's first preset. Spec-kit preset
+  (`schema_version: "1.0"`, `requires.speckit_version: ">=0.8.0"`) that
+  declares one command override under `provides.templates`:
+  `type: command`, `name: speckit.taskstoissues`,
+  `file: commands/speckit.taskstoissues.md`,
+  `replaces: speckit.taskstoissues` (default `replace` strategy).
+  Installable independently via:
+
+  ```bash
+  specify preset add taskstoissues-jira \
+    --from https://github.com/opsmill/opsmill-speckit/archive/refs/heads/main.zip \
+    --subdir presets/taskstoissues-jira
+  ```
+
+  Overrides the native `/speckit.taskstoissues` to fan `tasks.md` out
+  into Jira issues under a single Epic — one issue per `## Phase N:`
+  block, with `Blocks` links derived from `T<NNN>` mentions
+  (transitively reduced). Talks to Atlassian through the Atlassian MCP.
+  Project config lives at `dev/jira.yml` in the consumer repo; the
+  assignee is the user authenticated to the Atlassian MCP (resolved via
+  `atlassianUserInfo`). See
+  [`taskstoissues-jira/README.md`](taskstoissues-jira/README.md) for the
+  full configuration model and behavior.
+
+### Provenance
+`taskstoissues-jira` is ported from the Infrahub preset in
+[opsmill/infrahub#9208](https://github.com/opsmill/infrahub/pull/9208).
+Generalized for cross-repo reuse:
+- Project key + Epic key regex driven by `default_project_key` from
+  config rather than hardcoded `IFC`.
+- Custom field IDs reduced to placeholders (`customfield_XXXXX`);
+  operator resolves real IDs via `getJiraIssueTypeMetaWithFields`.
+- Preset id renamed from `infrahub` to `taskstoissues-jira` so the
+  install path reads as a portable Jira-flavored override of
+  `speckit.taskstoissues` rather than a single-product preset.

--- a/.specify/extensions/opsmill/presets/CHANGELOG.md
+++ b/.specify/extensions/opsmill/presets/CHANGELOG.md
@@ -19,7 +19,7 @@ and this collection adheres to [Semantic Versioning](https://semver.org/spec/v2.
 
   ```bash
   specify preset add taskstoissues-jira \
-    --from https://github.com/opsmill/opsmill-speckit/archive/refs/heads/main.zip \
+    --from https://github.com/opsmill/opsmill-speckit/archive/refs/tags/v1.0.0.zip \
     --subdir presets/taskstoissues-jira
   ```
 

--- a/.specify/extensions/opsmill/presets/taskstoissues-jira/README.md
+++ b/.specify/extensions/opsmill/presets/taskstoissues-jira/README.md
@@ -1,0 +1,57 @@
+# taskstoissues-jira
+
+A spec-kit preset that **overrides** the native `speckit.taskstoissues` command with a Jira-flavored implementation. One Jira issue is created per `## Phase N:` block in `tasks.md` (not per task line); inter-task `T<NNN>` mentions are resolved at phase granularity and emitted as `Blocks` issue links between phase issues (transitively reduced). All Atlassian traffic goes through the Atlassian MCP.
+
+## Install
+
+```bash
+specify preset add taskstoissues-jira \
+  --from https://github.com/opsmill/opsmill-speckit/archive/refs/heads/main.zip \
+  --subdir presets/taskstoissues-jira
+```
+
+Local development install (from a working tree):
+
+```bash
+specify preset add --dev ./presets/taskstoissues-jira
+```
+
+After install, the preset's files live at `.specify/presets/taskstoissues-jira/` in the consumer repo, and `/speckit.taskstoissues` resolves to this preset's command body.
+
+## Configuration model
+
+One file: `dev/jira.yml` at the consumer repo root, committed. It holds every Jira parameter the preset reads — `cloud`, `default_project_key`, `default_issue_type`, `custom_fields.*`, `team.name` / `team.id`, `labels_default`. The assignee for every created issue is the user authenticated to the Atlassian MCP, resolved via `atlassianUserInfo`.
+
+## One-time setup (per consumer repo)
+
+1. Copy the project template into place:
+
+   ```bash
+   mkdir -p dev
+   cp .specify/presets/taskstoissues-jira/templates/jira.example.yml dev/jira.yml
+   ```
+
+2. Edit `dev/jira.yml` and fill in every REQUIRED field:
+
+   - `cloud` — your Atlassian site URL (e.g. `https://opsmill.atlassian.net/`). Matched against `getAccessibleAtlassianResources` to resolve `cloudId`. The shipped example points at `https://opsmill.atlassian.net/`; replace if your tenant differs.
+   - `default_project_key` — your repo's Jira project key. The shipped placeholder `PROJ` aborts on purpose.
+   - `default_issue_type` — issue type for created phase issues (e.g. `Task`, `Story`).
+   - `custom_fields.epic_link` + `custom_fields.team` — real custom field IDs for your Jira instance. Resolve with `mcp__claude_ai_Atlassian__getJiraIssueTypeMetaWithFields` and replace each `customfield_XXXXX` placeholder.
+   - `team.name` — the Atlassian Team for every created issue. Leave `team.id` empty on first run; the command resolves it from `name` and writes the UUID back. Expect a `dev/jira.yml` diff after the first run — commit it.
+   - `labels_default` — labels stamped on every created issue (e.g. `[spec-kit]`).
+
+3. Commit `dev/jira.yml`. The whole repo shares it.
+
+Re-running `specify preset add taskstoissues-jira` only touches `.specify/presets/taskstoissues-jira/`, so `dev/jira.yml` is never clobbered by preset updates.
+
+## Epic resolution
+
+The command parses the current branch name for `<default_project_key>-\d+` (case-insensitive), falling back to `$ARGUMENTS`, then to an interactive prompt. The matched key is validated as an Epic via `getJiraIssue`.
+
+## Failure mode
+
+The run stops at the first `createJiraIssue` / `createIssueLink` error and prints the partial `phase_number → IssueKey` map. The command is **not** idempotent — delete the listed issues in Jira manually before retrying.
+
+## Provenance
+
+Ported from the Infrahub preset introduced in [opsmill/infrahub#9208](https://github.com/opsmill/infrahub/pull/9208). Generalized for cross-repo reuse: the Infrahub-specific project key (`IFC`) and custom field IDs become placeholders consumers fill in via `dev/jira.yml`.

--- a/.specify/extensions/opsmill/presets/taskstoissues-jira/commands/speckit.taskstoissues.md
+++ b/.specify/extensions/opsmill/presets/taskstoissues-jira/commands/speckit.taskstoissues.md
@@ -1,0 +1,190 @@
+---
+description: Convert tasks.md into Jira issues under a single Epic (one Jira issue per phase).
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks-to-issues conversion)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse `FEATURE_DIR` and `AVAILABLE_DOCS` list. All paths must be absolute. Extract the absolute path to `tasks.md` from `FEATURE_DIR`. For single quotes in args like "I'm Groot", use escape syntax: e.g `'I'\''m Groot'` (or double-quote if possible: `"I'm Groot"`).
+
+2. **Load project configuration**:
+   - Read the project-level Jira config from `dev/jira.yml` at the repo root. Required keys: `cloud`, `default_project_key`, `default_issue_type`, `custom_fields.epic_link`, `custom_fields.team`, `team.name`, `labels_default`. Optional: `team.id` (cached UUID; auto-populated on first run), additional `custom_fields.*` entries (e.g. `sprint`, `story_points`) for future use.
+
+     > [!CAUTION]
+     > If `dev/jira.yml` does not exist, abort with: `> dev/jira.yml not found. Copy .specify/presets/taskstoissues-jira/templates/jira.example.yml to dev/jira.yml at the repo root, fill in every REQUIRED field, and commit before re-running.`
+
+     > [!CAUTION]
+     > If any required top-level key is missing from `dev/jira.yml`, abort with: `> dev/jira.yml is missing required key '<key>'. See .specify/presets/taskstoissues-jira/templates/jira.example.yml for the full schema.` Do not silently default.
+
+     > [!CAUTION]
+     > If `default_project_key` still equals the example placeholder `PROJ`, abort with: `> dev/jira.yml still has placeholder default_project_key 'PROJ'. Set it to your repo's Jira project key before re-running.`
+
+     > [!CAUTION]
+     > If `custom_fields.epic_link` or `custom_fields.team` equals `customfield_XXXXX`, abort with: `> dev/jira.yml still has placeholder custom field IDs. Resolve real IDs with mcp__claude_ai_Atlassian__getJiraIssueTypeMetaWithFields and update the file before re-running.` Do not invent IDs.
+
+3. **Resolve Atlassian cloud id**: Call `mcp__claude_ai_Atlassian__getAccessibleAtlassianResources` once and match `cloud` from `dev/jira.yml` against the returned site URLs to obtain `cloudId`.
+
+   > [!CAUTION]
+   > If `cloudId` cannot be resolved, or `getAccessibleAtlassianResources` returns more than one site without a unique match to the configured `cloud`, abort with: `> Multiple Atlassian sites accessible — pin one in dev/jira.yml under 'cloud' before re-running.`
+
+4. **Resolve the Epic key**:
+   1. Run `git rev-parse --abbrev-ref HEAD`. Build a case-insensitive regex from `default_project_key` of the form `<default_project_key>-\d+` and match it against the branch name; uppercase the project-key portion of the match (e.g. with `default_project_key=IFC`, `pmi-ifc-2521-auto-create-groups` → `IFC-2521`).
+   2. If the branch yields no match, test `$ARGUMENTS` against the same pattern.
+   3. If still no match, prompt: `> Provide the Jira Epic for these tasks (e.g. <default_project_key>-1234):` and wait for input. Validate the input matches the same `<default_project_key>-\d+` pattern (case-insensitive).
+   4. Validate the resolved key by calling `mcp__claude_ai_Atlassian__getJiraIssue` and confirming `fields.issuetype.name == "Epic"`. Abort if it is not an Epic.
+
+5. **Resolve assignee account id**: Call `mcp__claude_ai_Atlassian__atlassianUserInfo` once and read `account_id` from the response. That is the accountId of the user currently authenticated to the Atlassian MCP — the same user running the command — and becomes the assignee for every issue created in this run. Cache it for the duration of this run.
+
+   > [!CAUTION]
+   > If `atlassianUserInfo` fails or returns no `account_id`, abort with: `> Atlassian MCP not authenticated. Authenticate the Atlassian MCP server before re-running.` Do not create any issues.
+
+6. **Resolve team UUID**: From `dev/jira.yml` read `team.name` and `team.id`. Jira's Atlassian Teams picker (`custom_fields.team`) only accepts a UUID — `team.name` is kept in `dev/jira.yml` as a human label, never sent to Jira.
+
+   - If `team.id` is set, use it as-is.
+   - If `team.id` is empty or missing, resolve it once via Atlassian:
+     1. Call `mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql` with:
+        - `cloudId` from step 3
+        - `jql = 'project = <default_project_key> AND "Team[Team]" is not EMPTY ORDER BY created DESC'`
+        - `fields = ["<custom_fields.team>"]`
+        - `maxResults = 20`
+     2. Scan the returned issues' `<custom_fields.team>.name` for an exact case-insensitive match to `team.name` from `dev/jira.yml`. Extract the matching `<custom_fields.team>.id` (the UUID).
+     3. If a match is found, persist the UUID back into `dev/jira.yml` at `team.id` so future runs skip this lookup, and use that UUID for issue creation.
+     4. If no match is found, abort with: `> Team '<team.name>' not found in Atlassian (searched recent issues in <default_project_key>). Set team.id explicitly in dev/jira.yml before re-running.` Do not create any issues.
+
+   Pass the resolved value to `createJiraIssue` as a **bare UUID string** (e.g. `"<custom_fields.team>": "079e72e1-..."`). The object form `{"id": "<uuid>"}` and the name form (e.g. `"Backend Team"`) are both rejected by Jira's Teams picker.
+
+7. **Parse `tasks.md` by phase**: Walk the file top-to-bottom and split it into phases, where a phase starts at a `## Phase <N>: <title>` header and ends at the next `## Phase` header (or end of file). For each phase capture:
+   - `phase_number` (`<N>`) and `phase_title` (`<title>`) from the header line
+   - `goal_block`: the `**Goal**:` paragraph immediately under the header, if present
+   - `independent_test_block`: the `**Independent Test**:` paragraph, if present
+   - `tasks`: every unchecked `- [ ] T<NNN> …` line inside the phase, preserved verbatim including its `[P]` and `[US<N>]` tags and trailing file paths. Skip tasks already checked (`- [x]`).
+   - `story`: if the phase header matches `User Story <n>` **or** every child task carries the same `[US<n>]` tag, capture `<n>` as the phase's user-story number; otherwise leave unset.
+   - `files`: the union of affected file paths across the phase's task lines (trailing the summary or on subsequent indented lines), deduplicated and sorted.
+   - `exit_criteria`: any trailing `**Exit criteria**` / `**Checkpoint**` paragraph in the phase, if present.
+
+   Skip phases that contain zero unchecked tasks. Build an ordered list `phases: [{phase_number, phase_title, story, goal_block, independent_test_block, tasks, files, exit_criteria}]`.
+
+8. **Create one Jira issue per phase**: For each parsed phase, call `mcp__claude_ai_Atlassian__createJiraIssue` with:
+   - `cloudId` from step 3.
+   - `projectKey` from `default_project_key`.
+   - `issueTypeName` from `default_issue_type`.
+   - `summary` = `phase_title` from step 7, with spec-kit-internal taxonomy tags stripped:
+     - `US<N>` tags — already captured as a `US<N>` label below.
+     - `P<N>` tags — already captured by the `Blocks` links in step 9.
+     - Bracketed `[…]` decorations carrying the same data (`[P]`, `[US<N>]`).
+
+     **Keep** meaningful tier markers (`MVP`, `Beta`, `Alpha`, etc.) and the descriptive feature text. Drop surrounding parentheses if their only remaining content is itself dropped (e.g. `(P1 MVP)` → `MVP`, but `(Beta)` stays as `(Beta)`).
+   - Examples:
+     - `Phase 3: US1 (P1 MVP) — Auto-create groups` → `"MVP — Auto-create groups"`
+     - `Phase 1: US2 — Bulk import` → `"Bulk import"`
+     - `Phase 2: (Beta) Pagination on lists` → `"(Beta) Pagination on lists"`
+   - `description` composed in this order:
+     1. The `goal_block` (if any).
+     2. The `independent_test_block` (if any).
+     3. A `## Tasks` section containing the phase's task lines as a markdown checklist — each entry is the verbatim `- [ ] T<NNN> …` line.
+     4. A `## Files` section listing each affected path from `files` as a bullet.
+     5. A `## Exit criteria` section reproducing `exit_criteria` (if any).
+     6. A trailing line `_Source:_ <relative path from repo root to tasks.md>`.
+   - `additional_fields`:
+     - `assignee`: `{ accountId: <resolved accountId> }`
+     - `labels`: `labels_default` (from `dev/jira.yml`) + `US<story>` if the phase has a `story` value
+     - `custom_fields`:
+       - `<custom_fields.epic_link>`: `<Epic key from step 4>` (e.g. `customfield_10014: "IFC-2521"`)
+       - `<custom_fields.team>`: the bare UUID string resolved in step 6 (e.g. `customfield_10001: "079e72e1-..."`). Never send the object form `{"id": "<uuid>"}` and never send `team.name`.
+
+   Record `phase_number -> issueKey` in an in-memory map.
+
+   > [!CAUTION]
+   > UNDER NO CIRCUMSTANCES CREATE ISSUES IN A PROJECT OTHER THAN `default_project_key` FROM `dev/jira.yml`.
+
+   > [!CAUTION]
+   > If any `createJiraIssue` call fails mid-run, **stop immediately**. Print the partial `phase_number -> issueKey` map and instruct: `> Partial run — delete the issues listed above manually in Jira before re-running. This skill is not idempotent in v1.` Do not retry, do not roll back automatically.
+
+9. **Create phase-level dependency links**: After every phase issue exists, derive the phase dependency graph from `T<NNN>` mentions inside each phase's task bodies:
+   1. Build a `tid -> phase_number` index from the parse in step 7 — every `T<NNN>` owned by a phase maps to that phase's `phase_number`.
+   2. For each phase `P`, scan its task bodies for `T<NNN>` mentions whose owning phase is **not** `P` itself. For each such mention, emit a directed edge `(phase_of_mentioned_tid) -> P` (the phase that owns the cited task blocks `P`).
+   3. Deduplicate edges, then apply a transitive reduction so only direct edges remain. If the graph has `A -> B`, `B -> C`, and `A -> C`, drop `A -> C`.
+   4. For each surviving edge `(blocker_phase) -> (blocked_phase)`, call `mcp__claude_ai_Atlassian__createIssueLink` with:
+      - `type` = `"Blocks"`
+      - `inwardIssue` = the blocker phase's Jira key (from the `phase_number -> issueKey` map)
+      - `outwardIssue` = the blocked phase's Jira key
+
+   Phase headers and `[P]` markers remain sequencing hints only — they are **not** first-class dependencies and must not produce link edges. The link source is exclusively `T<NNN>` mentions.
+
+10. **Summary output**: Print a markdown table mapping `Phase` → `IssueKey` → `Summary`. Do not edit `tasks.md` automatically; the user can paste the mapping back if they want.
+
+## Post-Execution Checks
+
+**Check for extension hooks (after tasks-to-issues conversion)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- When constructing slash commands from hook command names, replace dots (`.`) with hyphens (`-`). For example, `speckit.git.commit` → `/speckit-git-commit`.
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.specify/extensions/opsmill/presets/taskstoissues-jira/commands/speckit.taskstoissues.md
+++ b/.specify/extensions/opsmill/presets/taskstoissues-jira/commands/speckit.taskstoissues.md
@@ -116,7 +116,7 @@ You **MUST** consider the user input before proceeding (if not empty).
      - `P<N>` tags — already captured by the `Blocks` links in step 9.
      - Bracketed `[…]` decorations carrying the same data (`[P]`, `[US<N>]`).
 
-     **Keep** meaningful tier markers (`MVP`, `Beta`, `Alpha`, etc.) and the descriptive feature text. Drop surrounding parentheses if their only remaining content is itself dropped (e.g. `(P1 MVP)` → `MVP`, but `(Beta)` stays as `(Beta)`).
+     **Keep** meaningful tier markers (`MVP`, `Beta`, `Alpha`, etc.) and the descriptive feature text. Drop the surrounding parentheses whenever any tag inside them was stripped, leaving the kept content unwrapped (e.g. `(P1 MVP)` → `MVP`); keep the parentheses only when nothing inside them was stripped (e.g. `(Beta)` stays as `(Beta)`).
    - Examples:
      - `Phase 3: US1 (P1 MVP) — Auto-create groups` → `"MVP — Auto-create groups"`
      - `Phase 1: US2 — Bulk import` → `"Bulk import"`

--- a/.specify/extensions/opsmill/presets/taskstoissues-jira/preset.yml
+++ b/.specify/extensions/opsmill/presets/taskstoissues-jira/preset.yml
@@ -1,0 +1,28 @@
+schema_version: "1.0"
+
+preset:
+  id: "taskstoissues-jira"
+  name: "Tasks-to-Issues (Jira)"
+  version: "1.0.0"
+  description: "Override speckit.taskstoissues to fan tasks.md out into Jira issues under a single Epic (one issue per phase) via the Atlassian MCP."
+  author: "opsmill"
+  repository: "https://github.com/opsmill/opsmill-speckit"
+  license: "Apache-2.0"
+
+requires:
+  speckit_version: ">=0.8.0"
+
+provides:
+  templates:
+    - type: "command"
+      name: "speckit.taskstoissues"
+      file: "commands/speckit.taskstoissues.md"
+      description: "Convert tasks.md into Jira issues under a single Epic via the Atlassian MCP."
+      replaces: "speckit.taskstoissues"
+
+tags:
+  - "taskstoissues"
+  - "jira"
+  - "atlassian"
+  - "workflow"
+  - "opsmill"

--- a/.specify/extensions/opsmill/presets/taskstoissues-jira/templates/jira.example.yml
+++ b/.specify/extensions/opsmill/presets/taskstoissues-jira/templates/jira.example.yml
@@ -1,0 +1,38 @@
+---
+# Project-level Jira configuration for this repo.
+#
+# Copy this file to `dev/jira.yml` at your repo root, fill in real values,
+# and commit. Holds every Jira parameter the taskstoissues-jira preset
+# reads. The assignee for each created issue is the user authenticated
+# to the Atlassian MCP (resolved via atlassianUserInfo).
+
+# REQUIRED — Atlassian site URL. Matched against
+# getAccessibleAtlassianResources to resolve cloudId.
+cloud: https://opsmill.atlassian.net/
+
+# REQUIRED — Jira project key new issues are created in (e.g. IFC, INFP).
+default_project_key: PROJ
+
+# REQUIRED — issue type for created phase issues.
+default_issue_type: Task
+
+# REQUIRED — custom field IDs for your Jira instance. Retrieve with
+# mcp__claude_ai_Atlassian__getJiraIssueTypeMetaWithFields and paste below.
+custom_fields:
+  epic_link: customfield_XXXXX
+  team: customfield_XXXXX
+  # Optional / reserved for future use:
+  # sprint: customfield_XXXXX
+  # story_points: customfield_XXXXX
+
+# REQUIRED — Atlassian Team assigned to every created issue. `name` is the
+# human label; `id` is the bare UUID Jira's Teams picker requires. Leave
+# `id` empty on first run and the command will resolve it from `name` and
+# write it back here.
+team:
+  name: "Core"
+  id: ""
+
+# REQUIRED — labels applied to every created issue.
+labels_default:
+  - spec-kit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
     "ruff>=0.15.11",
     "pylint>=4.0.5",
     "yamllint>=1.37.1",
-    "infrahub-testcontainers>=1.9.8",
+    "infrahub-testcontainers>=1.10.0",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,21 @@ dev = [
     "ruff>=0.15.5",
     "pylint>=4.0.5",
     "yamllint>=1.37.1",
+    "infrahub-testcontainers>=1.9.8",
 ]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 filterwarnings = []
-addopts = "-p no:pytest-infrahub"
+# Default run = unit only: exclude the integration marker and disable the
+# infrahub-sdk / testcontainers pytest plugins (pulled in by the
+# infrahub-testcontainers dev dependency) so the fast loop stays Docker-free.
+# Run the integration suite with:  uv run pytest -m integration
+addopts = "-p no:pytest-infrahub -p no:pytest-infrahub-performance-test -m 'not integration'"
+markers = [
+    "integration: end-to-end tests against a real Infrahub container (require Docker; opt-in, excluded from the default run).",
+]
 
 [tool.mypy]
 pretty = true

--- a/specs/001-infrahub-testcontainers/checklists/requirements.md
+++ b/specs/001-infrahub-testcontainers/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Infrahub Testcontainers Integration Tests
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec deliberately names a few infrastructure concepts (Docker, container, pytest marker, CI job) because the feature itself is "integration tests via containers" — naming the testing paradigm is part of WHAT, not HOW. Specific image tags, library names, and code structure remain out of scope and will be decided in `/speckit-plan`.
+- "Write tools" and "branch listing" are MCP surface concepts already defined by the project; they are entity references, not implementation choices.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/001-infrahub-testcontainers/contracts/integration-test-surface.md
+++ b/specs/001-infrahub-testcontainers/contracts/integration-test-surface.md
@@ -1,0 +1,147 @@
+# Contract: MCP Surface Covered by Integration Tests (v1)
+
+**Feature**: 001-infrahub-testcontainers
+**Date**: 2026-05-22
+
+The Infrahub MCP server is itself the public contract. This document is not a new API — it is the **subset of the existing MCP server surface that the v1 integration suite asserts against**. Anything outside this list is covered by the unit suite only.
+
+Each item below lists: the MCP entity, the assertion shape, and which spec FR it backs.
+
+**Drive layer (clarified 2026-06-15)**: all assertions are made through the in-process FastMCP `Client` (in-memory transport) against the `mcp` server instance. The Starlette ASGI auth/OIDC/transport layer is bypassed; FastMCP-level middleware (`ReadOnlyMiddleware`, audit, caching, error handling) still runs — so the `read_only` write-gating contract (T4) and MCP-standard error masking (T3, F1) hold under this harness.
+
+---
+
+## R1. Schema resource (`schema://`)
+
+**MCP entity**: Resource — schema introspection.
+
+**Test contract**:
+
+- GIVEN the session-scoped seeded schema
+- WHEN the test reads the `schema` resource via the MCP client
+- THEN the response includes every kind declared in `tests/integration/fixtures/schema_minimal.yml`
+- AND the response shape conforms to `SchemaResource` Pydantic model
+
+**Backs**: FR-005 (schema resource), FR-012 (clear failure message).
+
+---
+
+## R2. Branches resource (`branches://`)
+
+**MCP entity**: Resource — branch listing.
+
+**Test contract**:
+
+- GIVEN a per-test branch has been created
+- WHEN the test reads the `branches` resource via the MCP client
+- THEN the response includes both `main` and the per-test branch name
+- AND `main` is flagged as the default branch
+
+**Backs**: FR-005 (branch listing).
+
+---
+
+## T1. `get_node` tool
+
+**MCP entity**: Tool (read).
+
+**Test contract** (per parametrized case):
+
+- GIVEN seeded baseline nodes on `main`
+- WHEN the test calls `get_node(kind=..., id=...)`
+- THEN the response includes the requested attributes and matches the seeded value
+- AND the response is deterministic across repeated calls
+
+**Backs**: FR-005 (node read tools).
+
+---
+
+## T2. `get_nodes` tool
+
+**MCP entity**: Tool (read).
+
+**Test contract** (at least 2 parametrized cases):
+
+1. **Filter**: GIVEN seeded nodes, WHEN `get_nodes(kind=..., filters={...})` is called, THEN only matching nodes are returned.
+2. **Pagination**: GIVEN ≥ N+1 seeded nodes of a kind, WHEN `get_nodes(kind=..., limit=N)` is called, THEN exactly N are returned AND a paging cursor (or equivalent) lets the next page be requested.
+
+**Backs**: FR-005 (node read tools), `get_nodes` pagination unit test parity (`tests/unit/test_get_nodes_pagination.py`).
+
+---
+
+## T3. `graphql_query` tool
+
+**MCP entity**: Tool (read).
+
+**Test contract**:
+
+- GIVEN a known seeded graph
+- WHEN the test calls `graphql_query(query=..., variables=...)` with a query against the seeded shape
+- THEN the response matches the expected shape
+- AND query errors (e.g., unknown field) surface as MCP-standard errors, not internal stack traces (Principle VI)
+
+**Backs**: FR-005 (GraphQL tool), Constitution Principle I and VI.
+
+---
+
+## T4. One representative write tool (e.g., `create_node`)
+
+**MCP entity**: Tool (write — tagged `"write"`).
+
+**Test contract**:
+
+- GIVEN a per-test branch and `read_only=false`
+- WHEN the test calls the write tool with valid input
+- THEN a new node exists on the per-test branch
+- AND the node does NOT appear on `main` (verifies Principle III: branch isolation)
+- AND when the per-test branch is deleted, the node disappears (verifies cleanup)
+
+Additionally:
+
+- GIVEN `read_only=true` (separate test class with reconfigured `McpServerUnderTest`)
+- WHEN the test calls the write tool
+- THEN the call is rejected with an MCP-standard error
+- AND no node is created on any branch
+
+**Backs**: FR-005 (write tool), Constitution Principles III and VI.
+
+---
+
+## V1. Infrahub version-compatibility check (FR-013)
+
+**MCP entity**: N/A — a backend version probe via the SDK (not an MCP tool/resource).
+
+**Test contract**:
+
+- GIVEN the running session Infrahub container
+- WHEN the version-compat test reads the running Infrahub version and compares it to the pinned / SDK-supported range
+- THEN a matching version passes
+- AND a mismatch produces a distinct, clearly-labeled result (an `xfail`/`skip` whose reason names both versions, or a "version drift"-labeled failure) — never an ordinary functional-assertion failure
+
+**Backs**: FR-013, "Infrahub version drift" edge case.
+
+---
+
+## Failure-mode contracts (cross-cutting)
+
+These assertions are not tied to a specific tool/resource; they apply to every integration test.
+
+- **F1**: When the Infrahub container is not reachable (simulated by tearing it down mid-suite), MCP calls return an MCP-standard error with no internal stack trace exposed.
+- **F2**: When a tool is called with malformed input, the MCP layer rejects it via FastMCP's schema enforcement before any Infrahub call is made (assertable by checking no SDK call was issued — uses a spy on the SDK client).
+
+---
+
+## Explicit non-contract
+
+The following are **NOT** asserted in v1 (covered by unit suite or deferred):
+
+- Prompt templates (rendering, parameter substitution).
+- OpenTelemetry trace emission shape.
+- Prometheus metrics shape.
+- Rate limiting middleware behavior under load.
+- Response caching middleware TTL semantics.
+- Audit middleware output format.
+- OIDC token validation flow (unit-tested with mocked IdP).
+- Token-passthrough flow (unit-tested in `tests/unit/test_token_passthrough.py`).
+
+Any of these may be added in a future increment without changing this v1 contract.

--- a/specs/001-infrahub-testcontainers/data-model.md
+++ b/specs/001-infrahub-testcontainers/data-model.md
@@ -1,0 +1,118 @@
+# Phase 1 Data Model: Integration Test Fixtures
+
+**Feature**: 001-infrahub-testcontainers
+**Date**: 2026-05-22
+
+Integration tests do not introduce production data. The "data model" here is the lifecycle of test fixtures and the seeded Infrahub state.
+
+## Entities
+
+### IntegrationTestSession
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `session_id` | `str` (pytest-generated) | Unique per `pytest` invocation. |
+| `infrahub_compose` | `InfrahubDockerCompose` | The upstream `infrahub-testcontainers` compose handle. |
+| `infrahub_ports` | `dict[str, int]` | Service-name → host port mapping returned by `infrahub_app` fixture. |
+| `infrahub_address` | `str` | `http://localhost:{infrahub_port}` resolved at fixture setup. |
+| `admin_token` | `str` | The upstream testcontainers initial admin token (`PROJECT_ENV_VARIABLES["INFRAHUB_TESTING_INITIAL_ADMIN_TOKEN"]`). |
+| `seeded` | `bool` | True after baseline schema + nodes are loaded. |
+
+**Lifecycle**: Created on first integration-test collection in a `pytest` run; destroyed at session teardown. Scope = `session`.
+
+**Identity**: `session_id`.
+
+**Transitions**: `created → starting → ready → seeded → in-use → tearing-down → destroyed`.
+
+### PerTestBranch
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `name` | `str` | Generated as `test-{nodeid-slug}-{uuid8}`. |
+| `parent` | `str` | Always `main` (the seeded baseline). |
+| `created_at` | `datetime` | Set by fixture setup. |
+| `deleted_at` | `datetime \| None` | Set by fixture teardown. |
+
+**Lifecycle**: Created at the start of each test (`function`-scoped fixture); deleted at test teardown regardless of pass/fail (try/finally).
+
+**Identity**: `name`. Branch name uniqueness is required by Infrahub.
+
+**Validation**: Branch name MUST satisfy Infrahub's branch-name character set (alphanumeric, hyphens, underscores, dots, slashes). The fixture generates names that conform.
+
+**Relationships**:
+
+- Each `PerTestBranch` belongs to exactly one `IntegrationTestSession`.
+- Each test function consumes exactly one `PerTestBranch`.
+
+### McpServerUnderTest
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `config` | `ServerConfig` | A `ServerConfig` instance pointed at the session's Infrahub address, write tools enabled (`read_only=false`). The Infrahub credential is the testcontainers admin token (`INFRAHUB_API_TOKEN`). No HTTP auth mode participates — the ASGI layer is not built. |
+| `server` | `FastMCP` | The composed `mcp` server instance from `src/infrahub_mcp/server.py`, configured for the session with FastMCP-level middleware via `configure_middleware()`. |
+| `client` | `fastmcp.Client` | In-process FastMCP client over the in-memory transport (`Client(mcp)`); no ASGI app, no HTTP, no auth/OIDC layer. FastMCP-level middleware (ReadOnly, audit, caching, error handling) still runs. |
+
+**Lifecycle**: Built once per session (after the Infrahub container is ready and seeded). The same MCP server instance serves all tests; per-test isolation comes from the `PerTestBranch`, not from spinning up a new MCP server per test. The `read_only=true` write-rejection contract (contracts T4) uses a separate server instance configured with `read_only=true`; this is valid because `ReadOnlyMiddleware` is a FastMCP-level middleware that runs under the in-memory transport.
+
+**Identity**: Singleton per session (the `read_only=true` variant is a separate, short-lived instance).
+
+**Transitions**: `unbuilt → built → ready → torn-down`.
+
+### SeedSchema
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `path` | `Path` | `tests/integration/fixtures/schema_minimal.yml`. |
+| `node_kinds` | `list[str]` | Names of the kinds the schema defines (e.g., `LocationSite`, `Device`). |
+| `loaded_at` | `datetime` | When the schema was loaded into Infrahub (once per session). |
+
+**Lifecycle**: Loaded once during session setup, before any per-test branch is created.
+
+**Validation**: The schema MUST be loadable by the Infrahub SDK against the session's Infrahub container; failure to load aborts the session.
+
+### SeedNodes
+
+A small fixed set of baseline node instances created on `main` once per session. Exact set is defined in `tests/integration/fixtures/seed.py` (Python so the SDK can be used directly).
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `kind` | `str` | One of the kinds in `SeedSchema.node_kinds`. |
+| `attributes` | `dict[str, Any]` | Concrete values per kind. |
+| `id` | `str` (assigned by Infrahub) | Captured at seed time, available to tests. |
+
+**Lifecycle**: Created once per session on `main`. Never mutated by tests (tests mutate per-test branches).
+
+## Validation Rules
+
+- The test harness MUST verify Docker is reachable before attempting to start the Infrahub compose; failure produces a clear error referencing FR-007.
+- The test harness MUST verify the Infrahub container is ready (HTTP 200 on `/api/schema`) before yielding the session fixture.
+- The test harness MUST clean up every `PerTestBranch` it creates, including on test interruption (use `addfinalizer` / `try-finally`).
+- Concurrent sessions MUST NOT share `IntegrationTestSession` state — each `pytest` invocation gets its own.
+
+## State Transitions (sequence)
+
+```text
+pytest collects integration tests
+  → IntegrationTestSession.created
+    → infrahub_compose.start()          [upstream fixture]
+      → IntegrationTestSession.ready    [HTTP probe passes]
+        → SeedSchema.load()             [SDK call]
+          → SeedNodes.create()          [SDK calls on main]
+            → IntegrationTestSession.seeded
+              → McpServerUnderTest.build()
+                ↓
+  for each test:
+    PerTestBranch.create()              [SDK: branch_create off main]
+      run test against MCP server, scoped to PerTestBranch
+    PerTestBranch.delete()              [SDK: branch_delete, in try/finally]
+  end for
+                ↓
+  → McpServerUnderTest.teardown()
+  → infrahub_compose.stop()              [upstream fixture]
+  → IntegrationTestSession.destroyed
+```
+
+## Out of Scope
+
+- Production Infrahub data: never touched by integration tests.
+- Generated MCP audit / log artifacts: emitted by the running MCP server but not part of the data model under test in v1 (see research.md D3).

--- a/specs/001-infrahub-testcontainers/plan.md
+++ b/specs/001-infrahub-testcontainers/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: Infrahub Testcontainers Integration Tests
+
+**Branch**: `001-infrahub-testcontainers` | **Date**: 2026-05-22 (updated 2026-06-15) | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-infrahub-testcontainers/spec.md`
+
+## Summary
+
+Add an integration test tier to the Infrahub MCP server that exercises the MCP surface (tools, resources, prompts) end-to-end against a real Infrahub instance provisioned via the upstream `infrahub-testcontainers` pytest fixture. One Infrahub Docker stack is spun up per test session and a fresh Infrahub branch is created per test for isolation (per the [clarification](./spec.md#clarifications) recorded 2026-05-22). The integration suite lives under `tests/integration/`, is opt-in via a `integration` pytest marker (default `uv run pytest` runs only unit tests, preserving the fast inner loop), and runs as a dedicated GitHub Actions job gating PRs to `stable`.
+
+Per the 2026-06-15 clarifications: tests drive the server via the **in-process FastMCP `Client`** against the module-level `mcp` server instance — the Starlette ASGI auth/OIDC/transport layer is bypassed (no OIDC issuer container needed), while FastMCP-level middleware (incl. `ReadOnlyMiddleware` write-gating, audit, caching) is still exercised. The suite also includes a dedicated **version-compatibility check** (FR-013) that asserts the running Infrahub version against the pinned/SDK-supported range and reports a distinct, clearly-labeled result so version drift is distinguishable from a functional regression.
+
+## Technical Context
+
+**Language/Version**: Python 3.13 (matches project)
+**Primary Dependencies**:
+
+- Existing: `infrahub-sdk>=1.20.0`, `fastmcp>=3.2.0`, `pytest>=8.4.1`, `pytest-asyncio>=1.1.0`
+- New (dev group): `infrahub-testcontainers` (PyPI, pinned to a specific Infrahub minor; ships `TestInfrahubDocker` base class and a docker-compose stack)
+
+**Storage**: N/A. The Infrahub container provisions its own Neo4j/Memgraph + Redis + task-worker stack via `infrahub-testcontainers`'s embedded `docker-compose.test.yml`.
+
+**Testing**:
+
+- Unit suite remains untouched at `tests/unit/`, runs without Docker.
+- Integration suite at `tests/integration/`, requires Docker, opt-in via `-m integration` or `pytest tests/integration`.
+- Session-scoped Infrahub container (one per `pytest` invocation); function-scoped per-test Infrahub branch.
+- Tests drive the MCP server via the in-process FastMCP `Client` against the module-level `mcp` server (ASGI auth/OIDC/transport bypassed; FastMCP-level middleware retained).
+
+**Target Platform**: Linux (CI: `ubuntu-latest`), macOS/Linux developer machines with Docker engine reachable.
+
+**Project Type**: Single project (library/MCP server).
+
+**Performance Goals**:
+
+- Full integration suite under 10 minutes locally (SC-001) — budget: container startup ~60–120s, ~15–25 tests at <10s each.
+- Default `uv run pytest` wall-clock unchanged within 5% (SC-002) — achieved by keeping integration tests off the default path.
+
+**Constraints**:
+
+- Docker engine MUST be available for integration runs; suite MUST fail fast with a clear message otherwise (FR-007).
+- Concurrent runs on the same host MUST not collide (FR-009); `infrahub-testcontainers` already allocates random host ports via `tmpdir_factory`.
+- Infrahub image version MUST be pinned and recorded (FR-008); we pin via `INFRAHUB_TESTING_IMAGE_VER` in CI and as a documented default for local runs.
+
+**Scale/Scope**:
+
+- ~15–25 integration tests covering: schema resource, branch listing/resource, node read tools (get/list with filters/pagination), GraphQL tool, one representative write tool gated on the existing `read_only=false` config, plus a version-compatibility check (FR-013) asserting the running Infrahub version against the pinned/SDK-supported range.
+- Single Infrahub session per CI job; one Infrahub branch per test.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Gates derived from `.specify/memory/constitution.md` v1.0.0:
+
+| Principle | Gate | Status |
+|-----------|------|--------|
+| I. MCP Protocol Compliance | Tests exercise the MCP surface as protocol-compliant clients; no protocol shortcuts. | Pass |
+| II. Infrahub SDK Integration | Test setup/teardown uses the SDK (`InfrahubClient`) for branch and fixture data ops; no raw HTTP. | Pass |
+| III. Branch-Safe by Default | Isolation model IS Infrahub branches — directly reinforces the principle; the one write-tool test runs on its own per-test branch. | Pass |
+| IV. Type Safety & Explicit Contracts | Fixtures and tests are fully typed; mypy is part of the existing `uv run pre-commit run` gate and will be applied to `tests/integration/`. | Pass |
+| V. Test Discipline | Feature ADDS a test tier; each integration test atomic, parametrized variants where appropriate, mirrors source structure (`tests/integration/test_*.py` parallels `src/infrahub_mcp/tools/*.py` and `src/infrahub_mcp/resources/*.py`). | Pass |
+| VI. Security & Input Boundaries | Fixture credentials are the upstream `infrahub-testcontainers` initial admin token (well-known test token, never a prod secret); no real Infrahub credentials enter tests. Tests drive the server via the in-process FastMCP client, so the ASGI auth/OIDC layer is bypassed (no OIDC issuer needed) while FastMCP-level middleware — including `ReadOnlyMiddleware` write-gating — is still exercised. | Pass |
+| VII. Simplicity & Maintainability | Reuse upstream `infrahub-testcontainers`; do NOT reimplement container orchestration. No new abstractions over pytest. | Pass |
+
+No gate violations require Complexity Tracking entries.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-infrahub-testcontainers/
+├── plan.md              # This file
+├── research.md          # Phase 0 — resolves deferred clarifications
+├── data-model.md        # Phase 1 — fixture data model & lifecycle
+├── quickstart.md        # Phase 1 — how to run integration tests locally
+├── contracts/
+│   └── integration-test-surface.md  # MCP surface covered by integration tests
+└── checklists/
+    └── requirements.md  # already exists from /speckit-specify
+```
+
+### Source Code (repository root)
+
+```text
+tests/
+├── unit/                          # existing — unchanged
+│   ├── conftest.py
+│   ├── test_*.py
+│   └── ...
+└── integration/                   # NEW
+    ├── __init__.py
+    ├── conftest.py                # session-scoped Infrahub container, per-test branch fixture, in-process FastMCP mcp_client fixture
+    ├── fixtures/
+    │   └── schema_minimal.yml     # minimal Infrahub schema seeded once per session
+    ├── test_schema_resource.py    # one file per MCP surface area
+    ├── test_branches_resource.py
+    ├── test_node_tools.py
+    ├── test_graphql_tool.py
+    ├── test_write_tool.py         # gated; runs only when write tools enabled
+    └── test_version_compat.py     # FR-013: assert running Infrahub version vs pinned/SDK range
+
+pyproject.toml                     # register `integration` marker; ensure addopts behavior intentional
+.github/workflows/ci.yml           # add `integration-tests` job (Docker-enabled ubuntu runner)
+```
+
+**Structure Decision**: Single project layout. The existing `tests/unit/` directory is preserved untouched; the new `tests/integration/` directory sits alongside it. Selection is by directory + marker, not by configuration acrobatics:
+
+```bash
+uv run pytest tests/unit          # fast, no Docker (default unchanged)
+uv run pytest tests/integration   # integration, requires Docker
+uv run pytest                     # default; excludes integration via `-m 'not integration'`
+```
+
+## Complexity Tracking
+
+No violations to track. All Constitution gates pass. The MCP drive-layer question (formerly a deferred clarification) is resolved by the 2026-06-15 clarification: integration tests use the in-process FastMCP client — the ASGI auth/OIDC layer is bypassed while FastMCP-level middleware is retained — see `research.md` D2.

--- a/specs/001-infrahub-testcontainers/plan.md
+++ b/specs/001-infrahub-testcontainers/plan.md
@@ -107,9 +107,9 @@ pyproject.toml                     # register `integration` marker; ensure addop
 **Structure Decision**: Single project layout. The existing `tests/unit/` directory is preserved untouched; the new `tests/integration/` directory sits alongside it. Selection is by directory + marker, not by configuration acrobatics:
 
 ```bash
-uv run pytest tests/unit          # fast, no Docker (default unchanged)
-uv run pytest tests/integration   # integration, requires Docker
-uv run pytest                     # default; excludes integration via `-m 'not integration'`
+uv run pytest tests/unit                        # fast, no Docker (default unchanged)
+uv run pytest tests/integration -m integration  # integration, requires Docker
+uv run pytest                                   # default; excludes integration via `-m 'not integration'`
 ```
 
 ## Complexity Tracking

--- a/specs/001-infrahub-testcontainers/quickstart.md
+++ b/specs/001-infrahub-testcontainers/quickstart.md
@@ -15,15 +15,17 @@ If Docker is unavailable, the suite fails fast with: `Docker engine not reachabl
 ## Run the full integration suite
 
 ```bash
-uv run pytest tests/integration
+uv run pytest tests/integration -m integration
 ```
+
+> The `-m integration` selector is required: the default `addopts` carries `-m "not integration"`, so a bare `pytest tests/integration` would deselect every test in the directory.
 
 Expected: ~3–10 minutes wall clock on a developer machine (image pull on first run accounts for the upper bound). Containers are torn down on exit, including on failure or Ctrl-C.
 
 ## Run a single integration test
 
 ```bash
-uv run pytest tests/integration/test_node_tools.py::test_get_nodes_with_filter -x
+uv run pytest tests/integration/test_node_tools.py::test_get_nodes_filter_by_color -m integration -x
 ```
 
 `-x` stops at first failure (useful while iterating).
@@ -31,7 +33,7 @@ uv run pytest tests/integration/test_node_tools.py::test_get_nodes_with_filter -
 ## Keep containers running after the suite for inspection
 
 ```bash
-INFRAHUB_TESTCONTAINERS_KEEP=1 uv run pytest tests/integration/test_graphql_tool.py -x
+INFRAHUB_TESTCONTAINERS_KEEP=1 uv run pytest tests/integration/test_graphql_tool.py -m integration -x
 ```
 
 When set, the session fixture skips its `stop()` call so you can `docker compose ls`, find the project name, and poke at the running Infrahub. Remember to tear it down manually with `docker compose -p <project> down -v` when done. The next non-KEEP run starts a brand-new stack.
@@ -49,7 +51,7 @@ This continues to behave as before this feature shipped: no Docker, no network, 
 The pinned default lives in `pyproject.toml` (`infrahub-testcontainers~=X.Y`). To run against a different Infrahub image (e.g., to reproduce a CI failure on a bumped version):
 
 ```bash
-INFRAHUB_TESTING_IMAGE_VER=1.10.0 uv run pytest tests/integration
+INFRAHUB_TESTING_IMAGE_VER=1.10.0 uv run pytest tests/integration -m integration
 ```
 
 This sets the image tag without modifying `pyproject.toml`. Useful for one-off comparisons; permanent bumps go through a normal PR that updates the lockfile.
@@ -61,13 +63,13 @@ If CI's `integration-tests` job fails:
 > **First check:** if the only failure is `test_version_compat` (FR-013), that's **version drift** — the pinned Infrahub image moved outside the range the `infrahub-sdk` supports — not a product regression. Reconcile the `infrahub-testcontainers` / `infrahub-sdk` versions instead of hunting a code bug.
 
 1. Note the Infrahub image version reported in the job's `setup-versions` step.
-2. Locally: `INFRAHUB_TESTING_IMAGE_VER=<that version> uv run pytest tests/integration/<failing test>::<name> -x -s`.
+2. Locally: `INFRAHUB_TESTING_IMAGE_VER=<that version> uv run pytest tests/integration/<failing test>::<name> -m integration -x -s`.
 3. If the test starts but the assertion fails: read the failure message — it includes the per-test branch name and (on real failure) the last ~200 lines of the `infrahub-server` and `task-worker` container logs.
 4. If the test never starts: check Docker (`docker info`), check for port conflicts (lsof on common Infrahub ports), confirm the image pulled.
 
 ## Concurrent runs
 
-Two `uv run pytest tests/integration` invocations on the same host work — each gets its own project name, ports, and stack. You'll feel it in Docker memory and CPU first; resource exhaustion will not manifest as a name collision.
+Two `uv run pytest tests/integration -m integration` invocations on the same host work — each gets its own project name, ports, and stack. You'll feel it in Docker memory and CPU first; resource exhaustion will not manifest as a name collision.
 
 ## What's *not* covered by integration tests
 

--- a/specs/001-infrahub-testcontainers/quickstart.md
+++ b/specs/001-infrahub-testcontainers/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Running Integration Tests
+
+**Feature**: 001-infrahub-testcontainers
+**Audience**: Contributors and maintainers running integration tests locally or debugging CI failures.
+
+## Prerequisites
+
+1. **Docker** engine running and reachable from the shell (`docker info` must succeed).
+2. **uv** installed (`uv --version`); project deps synced (`uv sync --all-groups`).
+3. **Network egress** to the Infrahub container registry (or a local cache with the pinned image already present).
+4. Python 3.13 (managed by `uv`).
+
+If Docker is unavailable, the suite fails fast with: `Docker engine not reachable — integration tests require Docker. See specs/001-infrahub-testcontainers/quickstart.md.`
+
+## Run the full integration suite
+
+```bash
+uv run pytest tests/integration
+```
+
+Expected: ~3–10 minutes wall clock on a developer machine (image pull on first run accounts for the upper bound). Containers are torn down on exit, including on failure or Ctrl-C.
+
+## Run a single integration test
+
+```bash
+uv run pytest tests/integration/test_node_tools.py::test_get_nodes_with_filter -x
+```
+
+`-x` stops at first failure (useful while iterating).
+
+## Keep containers running after the suite for inspection
+
+```bash
+INFRAHUB_TESTCONTAINERS_KEEP=1 uv run pytest tests/integration/test_graphql_tool.py -x
+```
+
+When set, the session fixture skips its `stop()` call so you can `docker compose ls`, find the project name, and poke at the running Infrahub. Remember to tear it down manually with `docker compose -p <project> down -v` when done. The next non-KEEP run starts a brand-new stack.
+
+## Run unit tests only (default — fast loop)
+
+```bash
+uv run pytest
+```
+
+This continues to behave as before this feature shipped: no Docker, no network, milliseconds-to-seconds total.
+
+## Override the Infrahub image version
+
+The pinned default lives in `pyproject.toml` (`infrahub-testcontainers~=X.Y`). To run against a different Infrahub image (e.g., to reproduce a CI failure on a bumped version):
+
+```bash
+INFRAHUB_TESTING_IMAGE_VER=1.10.0 uv run pytest tests/integration
+```
+
+This sets the image tag without modifying `pyproject.toml`. Useful for one-off comparisons; permanent bumps go through a normal PR that updates the lockfile.
+
+## Diagnose a CI failure locally
+
+If CI's `integration-tests` job fails:
+
+> **First check:** if the only failure is `test_version_compat` (FR-013), that's **version drift** — the pinned Infrahub image moved outside the range the `infrahub-sdk` supports — not a product regression. Reconcile the `infrahub-testcontainers` / `infrahub-sdk` versions instead of hunting a code bug.
+
+1. Note the Infrahub image version reported in the job's `setup-versions` step.
+2. Locally: `INFRAHUB_TESTING_IMAGE_VER=<that version> uv run pytest tests/integration/<failing test>::<name> -x -s`.
+3. If the test starts but the assertion fails: read the failure message — it includes the per-test branch name and (on real failure) the last ~200 lines of the `infrahub-server` and `task-worker` container logs.
+4. If the test never starts: check Docker (`docker info`), check for port conflicts (lsof on common Infrahub ports), confirm the image pulled.
+
+## Concurrent runs
+
+Two `uv run pytest tests/integration` invocations on the same host work — each gets its own project name, ports, and stack. You'll feel it in Docker memory and CPU first; resource exhaustion will not manifest as a name collision.
+
+## What's *not* covered by integration tests
+
+See [contracts/integration-test-surface.md](./contracts/integration-test-surface.md) for the exact coverage scope. Prompts, OIDC flow, token-passthrough, rate limiting, and caching middleware behavior remain in the unit suite — there is no need to re-run integration to validate those.

--- a/specs/001-infrahub-testcontainers/research.md
+++ b/specs/001-infrahub-testcontainers/research.md
@@ -132,9 +132,9 @@ Crucially, FastMCP-level middleware (those subclassing `fastmcp.server.middlewar
 
 **Decision**: Document the following in `quickstart.md`:
 
-- `uv run pytest tests/integration` — full integration run.
-- `INFRAHUB_TESTCONTAINERS_KEEP=1 uv run pytest tests/integration` — leave containers up on exit for inspection (implemented via a small env-var check in the session-scoped fixture's teardown).
-- Per-test selection: `uv run pytest tests/integration/test_node_tools.py::test_get_nodes_with_filter`.
+- `uv run pytest tests/integration -m integration` — full integration run.
+- `INFRAHUB_TESTCONTAINERS_KEEP=1 uv run pytest tests/integration -m integration` — leave containers up on exit for inspection (implemented via a small env-var check in the session-scoped fixture's teardown).
+- Per-test selection: `uv run pytest tests/integration/test_node_tools.py::test_get_nodes_filter_by_color -m integration`.
 
 **Rationale**: Common developer flows. The `KEEP=1` toggle is the lowest-cost way to satisfy the implicit "let me poke at it when it breaks" workflow without violating FR-004 by default (default still tears down).
 
@@ -164,7 +164,7 @@ Crucially, FastMCP-level middleware (those subclassing `fastmcp.server.middlewar
 
 **Decision**: Rely on `infrahub-testcontainers`' existing behavior: it allocates a per-session `tmp_directory` via `tmpdir_factory`, creates a uniquely-named docker-compose project under that directory, and lets Docker assign random host ports. No additional work needed in our test code.
 
-**Rationale**: The upstream fixture already isolates by project name and ephemeral ports. Two concurrent `uv run pytest tests/integration` invocations on the same host will get two independent Infrahub stacks.
+**Rationale**: The upstream fixture already isolates by project name and ephemeral ports. Two concurrent `uv run pytest tests/integration -m integration` invocations on the same host will get two independent Infrahub stacks.
 
 **Risk**: If a developer runs *many* parallel sessions, Docker resource exhaustion (memory, port range) becomes the limit, not name collisions. Documented in `quickstart.md`.
 

--- a/specs/001-infrahub-testcontainers/research.md
+++ b/specs/001-infrahub-testcontainers/research.md
@@ -1,0 +1,196 @@
+# Phase 0 Research: Infrahub Testcontainers Integration Tests
+
+**Feature**: 001-infrahub-testcontainers
+**Date**: 2026-05-22
+
+This document resolves the technical unknowns from the plan's Technical Context. The 2026-06-15 `/speckit-clarify` session answered the test-separation, MCP drive-layer, and version-drift questions directly in [spec.md → Clarifications](./spec.md#clarifications); D2, D6, and D11 below are aligned with those answers. Each section is a Decision / Rationale / Alternatives record.
+
+---
+
+## D1. Test isolation model (resolved during clarification — recorded here for completeness)
+
+**Decision**: One Infrahub container per pytest session + one fresh Infrahub branch per test (created at fixture setup, deleted at teardown).
+
+**Rationale**: Recorded in [spec.md → Clarifications](./spec.md#clarifications). Branch-per-test leverages Infrahub's native versioning as the isolation primitive, avoids the ~60–120s container-startup cost per test, and matches Constitution principle III ("Branch-Safe by Default").
+
+**Alternatives considered**:
+
+- Container-per-test: too slow given SC-001's 10-minute budget.
+- Reseed/reset per test: brittle, has to enumerate all mutations to undo them.
+- No isolation: fails FR-011 (deterministic starting state).
+
+---
+
+## D2. MCP server drive layer & authentication during integration tests
+
+**Decision** (clarified 2026-06-15): Drive the MCP server via the **in-process FastMCP `Client`** (FastMCP in-memory transport) against the module-level `mcp` server instance from `src/infrahub_mcp/server.py`. The Starlette **ASGI auth/OIDC/transport layer is bypassed entirely** — no ASGI app is built and no HTTP auth mode (`none`/`oidc`/passthrough) participates, because that layer never runs under the in-memory transport. The MCP-server-to-Infrahub credential is the upstream testcontainers admin token, configured on `ServerConfig` (`INFRAHUB_API_TOKEN`).
+
+Crucially, FastMCP-level middleware (those subclassing `fastmcp.server.middleware.Middleware` with `on_call_tool` hooks — `ReadOnlyMiddleware`, `AuditMiddleware`, caching, rate-limiting, error handling) **still runs** under the in-memory transport, so write-gating and error-masking behavior remain under integration coverage. Only the HTTP/ASGI layer (`_CredentialsPassthroughASGI`, `_OAuthDiscoveryInterceptASGI`, OIDC discovery) is skipped.
+
+**Rationale**:
+
+- The feature under integration test is the MCP↔Infrahub contract, not the HTTP auth/transport layer. The unit suite already exhaustively covers OIDC, token-passthrough, and basic-passthrough (`test_auth.py`, `test_token_passthrough.py`, `test_middleware.py`).
+- The in-process client is the simplest possible harness: no ASGI app construction, no auth ceremony, no fake OIDC issuer container — keeping each test focused on the Infrahub interaction.
+- Because FastMCP-level middleware still executes, `ReadOnlyMiddleware` write-gating (Principle III) is genuinely exercised end-to-end against a real Infrahub, not mocked.
+
+**Constitution alignment**: Principle VI (auth validated at startup) is unaffected — startup auth validation is unit-tested; the integration suite simply does not stand up the HTTP transport. Principle I (MCP protocol compliance) is preserved: the FastMCP in-memory client speaks the MCP protocol to the same server object a network client would.
+
+**Alternatives considered**:
+
+- Full ASGI app via `build_app(config)` + in-process `httpx` client in `none` auth mode (the pre-clarification approach): rejected 2026-06-15 — exercises the ASGI auth layer the unit suite already covers and forces auth-mode bookkeeping into every fixture without new MCP↔Infrahub signal.
+- HTTP transport with a fake OIDC issuer: rejected — adds containers and complexity without new signal.
+- Token-passthrough smoke test: may be added later as a thin unit-level or HTTP smoke test if the boundary feels too sharp; out of scope for v1.
+
+---
+
+## D3. MCP surface coverage scope for integration tests
+
+**Decision**: Cover the following surface in v1:
+
+1. `schema` resource (MCP resource read) — verify schema content matches the seeded Infrahub schema.
+2. `branches` resource (MCP resource read) — verify branches list includes `main` plus per-test branch.
+3. Node read tools: `get_node`, `get_nodes` (with at least one filter and one paginated case).
+4. `graphql_query` tool — one read query against the seeded data.
+5. One write tool (`create_node` or equivalent) — gated by `read_only=false` and isolated to the per-test branch.
+
+**Out of scope for v1** (may be added later, recorded here for clarity): prompt templates, OpenTelemetry traces, rate limiting middleware behavior, response caching behavior, audit middleware output. The unit suite already covers these; adding integration coverage is incremental and not blocking.
+
+**Rationale**: This is the minimum surface that catches MCP↔Infrahub contract drift (schema shape, branch model, node response shape, GraphQL response shape, write path). It maps directly to FR-005.
+
+**Alternatives considered**:
+
+- Cover every tool/resource/prompt: rejected — combinatorial growth, diminishing returns, would blow past 10-minute budget.
+- Cover only reads: rejected — write path is the most consequential for branch-safety regression detection (Principle III).
+
+---
+
+## D4. CI trigger model and gating
+
+**Decision**: Add a new GitHub Actions job `integration-tests` in `.github/workflows/ci.yml`:
+
+- Triggers: same `pull_request` + push to `stable`/`develop` as the existing `ci.yml` workflow.
+- Conditional on `files-changed.outputs.mcp == 'true'` (existing path filter) to avoid spending CI minutes on docs-only PRs.
+- Runs on `ubuntu-latest` (Docker available by default).
+- Steps: setup-python + setup-uv → `uv sync --all-groups` → `uv run pytest tests/integration -m integration --tb=short`.
+- Configured as a required check in branch protection for `stable` (separate, post-merge configuration step — documented in `quickstart.md`).
+
+**Rationale**: Reuses the existing `files-changed` filter and `prepare-environment` job that the project already invests in. New job, not extended `python-lint` job, because failure modes and timing are very different (10 minutes vs. 1 minute).
+
+**Alternatives considered**:
+
+- On-demand label-triggered: rejected — defeats SC-003's "100% of PRs" goal.
+- Run inside the existing test job: rejected — couples slow integration to the fast lint feedback the project already has.
+- Self-hosted runner with Docker preinstalled: rejected — `ubuntu-latest` already ships Docker; no preinstall needed.
+
+---
+
+## D5. Infrahub image version pinning policy
+
+**Decision**: Pin `infrahub-testcontainers` to a specific minor version in `pyproject.toml` (e.g., `infrahub-testcontainers~=1.9`). The Infrahub container image version is derived from this package by default (the package's `__version__` is used unless `INFRAHUB_TESTING_IMAGE_VER` overrides it). CI sets `INFRAHUB_TESTING_IMAGE_VER` to a single specific version to remove drift between local and CI. A monthly Renovate/Dependabot PR proposes the version bump; bumps are reviewable like any other dependency change.
+
+**Rationale**: Satisfies FR-008 (pinned, reviewable, reproducible). Single-version (no matrix) keeps CI minutes in check; we will add matrix testing if/when we ship Infrahub-version-conditional code paths.
+
+**Alternatives considered**:
+
+- Float to latest: rejected — non-reproducible, makes "integration test failure" indistinguishable from "Infrahub released a breaking change."
+- Multi-version matrix (e.g., latest + N-1): rejected for v1 — 2x CI cost without a current need; revisit when we explicitly support multiple Infrahub versions.
+
+---
+
+## D6. Marker, addopts, and default-suite separation
+
+**Decision**:
+
+- Register `integration` as a custom marker in `pyproject.toml` under `[tool.pytest.ini_options]`.
+- Apply `@pytest.mark.integration` to every test in `tests/integration/` via an `pytestmark = pytest.mark.integration` module-level statement in each integration test file (or via a `conftest.py`-level autouse marker).
+- Keep the default `addopts = "-p no:pytest-infrahub"` so the infrahub pytest plugin stays inactive for the fast unit loop (it pulls in Docker/Infrahub machinery unit tests must not need). The integration command re-enables the plugin (e.g. `uv run pytest -p pytest-infrahub tests/integration`, or scoped via a `tests/integration`-local config) since the `infrahub-testcontainers` fixtures are surfaced through it. The exact re-enable mechanism (CLI flag vs. integration-local `addopts`) is settled in implementation; the contract is: **default = plugin off, integration = plugin on**, matching the spec clarification.
+- Add a default `-m 'not integration'` selector to keep `uv run pytest` (no args) running only unit tests. Override locally with `uv run pytest -m integration` or `uv run pytest tests/integration`.
+
+**Rationale**: Satisfies SC-002 (unit-suite wall-clock unchanged), FR-002 (suites separated), and FR-003 (single command). Mirrors a common pytest idiom widely understood by contributors.
+
+**Alternatives considered**:
+
+- Separate top-level `integration-tests/` directory outside `tests/`: rejected — splits discoverability.
+- Conftest-only opt-in (no marker): rejected — markers are the standard pytest mechanism and play well with CI filters and IDE plugins.
+
+---
+
+## D7. Test failure observability
+
+**Decision**: On test failure, the suite must surface (a) the failing test name and the Pytest assertion, (b) the last ~200 lines of `infrahub-server` and `task-worker` container logs (the upstream `TestInfrahubDocker.infrahub_app` fixture already emits these on per-class teardown when failures occurred), and (c) the branch name used for the failing test, so a developer can reproduce against the same branch if the container is left running for ad-hoc inspection (`--keep-containers` style flag — see D8).
+
+**Rationale**: Satisfies FR-012.
+
+**Alternatives considered**:
+
+- Full container logs on every failure: rejected — flood. ~200 lines is enough for most signal.
+- No log dump (rely on test assertion only): rejected — most integration failures need backend log context to diagnose.
+
+---
+
+## D8. Local developer ergonomics
+
+**Decision**: Document the following in `quickstart.md`:
+
+- `uv run pytest tests/integration` — full integration run.
+- `INFRAHUB_TESTCONTAINERS_KEEP=1 uv run pytest tests/integration` — leave containers up on exit for inspection (implemented via a small env-var check in the session-scoped fixture's teardown).
+- Per-test selection: `uv run pytest tests/integration/test_node_tools.py::test_get_nodes_with_filter`.
+
+**Rationale**: Common developer flows. The `KEEP=1` toggle is the lowest-cost way to satisfy the implicit "let me poke at it when it breaks" workflow without violating FR-004 by default (default still tears down).
+
+**Alternatives considered**:
+
+- Always tear down regardless: rejected — too costly for ad-hoc debugging.
+- Wrapper CLI command: rejected — adds dependency surface; env-var toggle is enough.
+
+---
+
+## D9. Test data seeding strategy
+
+**Decision**: One session-scoped fixture seeds a minimal schema (`tests/integration/fixtures/schema_minimal.yml`) and a small set of baseline nodes into the `main` branch immediately after container readiness. Per-test branches are created off this baseline; mutations in tests stay on the per-test branch. Tests never modify `main` after seeding.
+
+**Rationale**: Constitution III. Also makes branch isolation effective — if mutations leaked to `main`, branch-per-test wouldn't isolate them.
+
+**Schema scope**: Keep the seeded schema *minimal* — just enough to exercise the MCP surface. Reuse an existing demo schema fragment (such as the SDK's `LocationSite` shape already referenced in `tests/unit/conftest.py:locationsite_filters`) so unit and integration fixtures share a mental model.
+
+**Alternatives considered**:
+
+- Use Infrahub's full demo schema: rejected — slow to load, more failure modes unrelated to MCP.
+- Per-test schema reseeding: rejected — schemas are session-stable; branch is the right unit.
+
+---
+
+## D10. Concurrent test runs on the same host (FR-009)
+
+**Decision**: Rely on `infrahub-testcontainers`' existing behavior: it allocates a per-session `tmp_directory` via `tmpdir_factory`, creates a uniquely-named docker-compose project under that directory, and lets Docker assign random host ports. No additional work needed in our test code.
+
+**Rationale**: The upstream fixture already isolates by project name and ephemeral ports. Two concurrent `uv run pytest tests/integration` invocations on the same host will get two independent Infrahub stacks.
+
+**Risk**: If a developer runs *many* parallel sessions, Docker resource exhaustion (memory, port range) becomes the limit, not name collisions. Documented in `quickstart.md`.
+
+---
+
+## D11. Infrahub version-compatibility check (FR-013)
+
+**Decision** (clarified 2026-06-15): Add one dedicated integration test (`tests/integration/test_version_compat.py`) that reads the running Infrahub version (via the SDK — e.g. the `/api/version` info the SDK surfaces) and asserts it falls within the version range the pinned `infrahub-sdk` supports. On mismatch it emits a **clearly-labeled, distinct result** — an `xfail`/`skip` whose `reason` names both versions, or a dedicated assertion failure whose message is unmistakably "version drift", not a functional regression.
+
+**Rationale**: Satisfies FR-013 and resolves the "Infrahub version drift" edge case. A single focused check means a version bump that outpaces the SDK shows up as one obviously-labeled signal in CI output instead of a confusing scatter of functional-test failures. Low cost (one test), high triage value.
+
+**Mechanism notes**:
+
+- The check is itself marked `integration` (it needs the running container) and runs early so its signal precedes functional failures.
+- Source of truth for the "supported range" is the pinned `infrahub-sdk` version's declared compatibility (documented in `quickstart.md`); when no machine-readable range is available, assert against the pinned `INFRAHUB_TESTING_IMAGE_VER` and treat divergence as drift.
+- Reports via pytest's standard mechanisms; no new reporting infrastructure.
+
+**Alternatives considered**:
+
+- Documentation + manual triage only: rejected — relies on a human noticing; the spec promises the suite itself distinguishes drift.
+- Drop the expectation: rejected — loses the edge case the spec commits to.
+
+---
+
+## Summary
+
+All NEEDS CLARIFICATION items resolved. D2 (drive layer), D6 (separation), and D11 (version-compat check) reflect the 2026-06-15 clarifications. No item deferred to Phase 1.
+
+Phase 0 status: **complete**.

--- a/specs/001-infrahub-testcontainers/spec.md
+++ b/specs/001-infrahub-testcontainers/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: Infrahub Testcontainers Integration Tests
+
+**Feature Branch**: `001-infrahub-testcontainers`
+**Created**: 2026-05-22
+**Status**: Draft
+**Input**: User description: "I want to use infrahub testcontainers to run integration tests"
+
+## Clarifications
+
+### Session 2026-05-22
+
+- Q: Which isolation model should each integration test run against? → A: One Infrahub container per session + new Infrahub branch per test
+
+### Session 2026-06-15
+
+- Q: How should integration tests be separated from unit tests so the default run stays Docker-free? → A: A dedicated `tests/integration/` directory AND a `@pytest.mark.integration` marker; the default run excludes integration tests (`-m "not integration"`) and keeps the infrahub pytest plugin disabled, while the integration run targets the directory with the plugin enabled.
+- Q: At what layer should the integration tests drive the MCP server against the real Infrahub? → A: Via the in-process FastMCP client against the server instance (auth/transport middleware bypassed), keeping the suite focused on the Infrahub-facing contract; the middleware/auth layers retain their existing unit coverage. No OIDC provider container is required.
+- Q: How should the suite make Infrahub version drift distinguishable from a real product regression? → A: A dedicated version-compatibility check reads the running Infrahub version and asserts it matches the pinned/SDK-supported range, emitting a clearly-labeled distinct result (failure or xfail/skip) so drift is not confused with a functional regression.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Validate MCP server behavior against a real Infrahub (Priority: P1)
+
+A maintainer changes the MCP server (for example, the schema resource, a node tool, or the GraphQL tool) and wants confidence that the change still works end-to-end against a real, running Infrahub — not just against mocks. They run the integration test suite locally; the suite provisions an ephemeral Infrahub instance, exercises the MCP server against it, and reports pass/fail.
+
+**Why this priority**: This is the core value of the feature. Today the test suite is entirely unit-level with mocked Infrahub interactions, so contract drift between the MCP server and a real Infrahub (schema changes, SDK behavior, response shapes) is invisible until a user hits it. Catching this in CI/local dev is the whole point.
+
+**Independent Test**: Can be fully validated by running a single command (e.g., the integration test entry point) on a developer machine with Docker available, and observing that an Infrahub container starts, integration tests execute against it, the container is torn down, and a clear pass/fail summary is produced.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean developer machine with Docker available and project dependencies installed, **When** the maintainer invokes the integration test command, **Then** an Infrahub instance is provisioned, integration tests run against it, all containers are torn down on exit, and the test result is reported.
+2. **Given** a regression has been introduced in the MCP server's interaction with Infrahub (for example, a tool now sends a malformed query), **When** the integration test suite runs, **Then** at least one integration test fails with a clear, actionable message pointing to the regression.
+3. **Given** the integration test suite has finished (whether passing or failing), **When** the maintainer inspects the local Docker state, **Then** no Infrahub containers, networks, or volumes created by the test run remain.
+
+---
+
+### User Story 2 - Run integration tests in CI on every change (Priority: P2)
+
+A maintainer opens a pull request. The CI pipeline automatically runs the integration test suite against an ephemeral Infrahub instance and blocks merge if any integration test fails. PR authors and reviewers can see the integration test outcome alongside unit test results.
+
+**Why this priority**: Local-only integration tests catch regressions for the maintainer who runs them, but only CI enforcement ensures every contribution is validated. This builds on Story 1 and is unlocked once the local flow is reliable.
+
+**Independent Test**: Can be validated by opening a pull request that intentionally breaks the MCP server's interaction with Infrahub and observing that the CI integration test job fails and prevents merge under the project's branch protection rules.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pull request introducing a change to MCP server code, **When** CI runs, **Then** the integration test job executes and its result is visible on the pull request.
+2. **Given** an integration test fails in CI, **When** a reviewer inspects the job output, **Then** they can identify which test failed and see enough log context to begin diagnosis without re-running locally.
+3. **Given** an integration test job completes (pass or fail), **When** the CI runner is reused for the next job, **Then** no leftover Infrahub state from the previous run interferes with subsequent jobs.
+
+---
+
+### User Story 3 - Keep the fast unit-test loop intact (Priority: P2)
+
+A maintainer working on a non-integration change wants the existing fast unit test loop (`uv run pytest`) to remain quick and dependency-free. Integration tests should be opt-in (or clearly separated) so day-to-day development is not slowed by container startup.
+
+**Why this priority**: Equal priority with CI enforcement because the fast inner-loop is a known productivity gain that integration tests must not erode. Without this guarantee, maintainers will start skipping or disabling tests.
+
+**Independent Test**: Can be validated by running the default test command and observing that no Docker containers are started and total runtime stays comparable to the current unit-test baseline (within a small tolerance for any shared fixtures).
+
+**Acceptance Scenarios**:
+
+1. **Given** the default test command, **When** it runs, **Then** only unit tests execute and no Docker containers are started.
+2. **Given** the integration-test command (or marker/flag), **When** it runs, **Then** integration tests execute and unit tests may also run, but the developer has explicitly opted into the longer run.
+3. **Given** documentation describing how to run tests, **When** a new contributor reads it, **Then** they understand which command runs unit tests, which runs integration tests, and what prerequisites each has.
+
+---
+
+### Edge Cases
+
+- **Docker unavailable**: When a developer runs the integration suite on a machine without a working Docker engine, the suite must fail fast with a clear, actionable message naming the missing prerequisite — not hang or produce confusing internal errors.
+- **Port conflicts**: When the host already has a service occupying a port the Infrahub container would otherwise use, the integration suite must either pick an alternate port automatically or fail with a clear conflict message identifying the port.
+- **Slow container startup**: When the Infrahub container takes longer than usual to become ready, the suite must wait for a readiness signal up to a defined timeout, then fail with a clear timeout message rather than running tests against a not-yet-ready instance.
+- **Test interrupted (Ctrl-C, CI cancel)**: When the test run is interrupted partway through, container cleanup must still occur so the host (or CI runner) is left in a clean state.
+- **Image pull failure / offline**: When the required Infrahub image cannot be pulled (no network, registry outage), the suite must fail with a clear message naming the unreachable image, not a generic Docker error.
+- **Parallel test runs**: When two integration test runs are started concurrently on the same host (e.g., two developers, or CI matrix), they must not collide on container names, networks, or ports.
+- **Infrahub version drift**: When the pinned Infrahub image version diverges from the version the project's SDK targets, the suite must surface this via a dedicated version-compatibility check (see FR-013) that reports a distinct, clearly-labeled result rather than a generic test failure, so it is distinguishable from a real product regression.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The project MUST provide an integration test suite that exercises the MCP server end-to-end against a real, ephemeral Infrahub instance provisioned via containers.
+- **FR-002**: The integration test suite MUST be separated from the existing unit test suite using BOTH a dedicated `tests/integration/` directory and a `@pytest.mark.integration` marker. The default test command MUST exclude integration tests (e.g., `-m "not integration"`) and keep the infrahub pytest plugin disabled, so it continues to run without requiring Docker or network access; the integration command MUST target the integration directory with the plugin enabled.
+- **FR-003**: The integration test suite MUST be invocable by a single, documented command that handles container provisioning, test execution, and teardown.
+- **FR-004**: Containers, networks, and volumes created by an integration test run MUST be torn down on suite exit, including the case where tests fail or the run is interrupted.
+- **FR-005**: The integration test suite MUST cover the externally observable MCP surface area that depends on Infrahub: at minimum the schema resource, branch listing, node read tools, the GraphQL tool, and one representative write tool (gated by the existing write-tools enablement flag). Tests MUST drive the MCP server via the in-process FastMCP client against the server instance (auth/transport middleware bypassed) so the suite stays focused on the Infrahub-facing contract; no OIDC provider is provisioned, and the middleware/auth layers retain their existing unit coverage.
+- **FR-006**: The integration test suite MUST run in CI on every pull request and its result MUST be reported as a distinct check that can gate merges.
+- **FR-007**: The integration test suite MUST fail fast with a clear, human-readable message when its prerequisites (e.g., Docker engine availability, required image) are not met.
+- **FR-008**: The integration test suite MUST pin the Infrahub container image to a specific, recorded version so test results are reproducible across machines and over time, and so an image version bump is an explicit, reviewable change.
+- **FR-009**: The integration test suite MUST tolerate concurrent runs on the same host without collisions on container names, networks, or ports.
+- **FR-010**: Documentation MUST describe how to run integration tests locally, the prerequisites, and how the suite differs from unit tests.
+- **FR-011**: The suite MUST provision exactly one Infrahub instance per test session and isolate individual tests by creating a dedicated Infrahub branch per test (deleted on test teardown), so every test runs against a known, deterministic starting state independent of test order.
+- **FR-012**: The integration test suite MUST surface a clear, actionable failure message when an integration test fails, including enough context (test name, observed vs. expected, relevant Infrahub state) to begin diagnosis without re-running.
+- **FR-013**: The integration test suite MUST include a dedicated version-compatibility check that reads the running Infrahub version and asserts it matches the pinned/SDK-supported range, emitting a clearly-labeled, distinct result (failure or `xfail`/skip) so version drift is distinguishable from a functional product regression.
+
+### Key Entities
+
+- **Integration test suite**: A new, separately invocable body of tests living in a dedicated `tests/integration/` directory and tagged with the `@pytest.mark.integration` marker, so the two suites can be run independently.
+- **Ephemeral Infrahub instance**: A real Infrahub deployment provisioned once per test session inside Docker containers, used as the system-under-test's backend, and destroyed at the end of the session.
+- **Per-test Infrahub branch**: An Infrahub branch created at the start of each test (off a clean, session-seeded baseline) and deleted at teardown; the unit of test isolation that lets concurrent tests share a single Infrahub container.
+- **Test fixture data**: Deterministic seed data loaded into the Infrahub instance once per session (schemas, baseline branches, sample nodes) so per-test branches have a known starting state.
+- **CI integration job**: The CI pipeline step responsible for executing the integration suite, reporting its result, and ensuring its outcome can gate pull-request merges.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A maintainer with Docker installed can run the integration test suite from a clean checkout with a single documented command in under 10 minutes (including container startup, all tests, and teardown).
+- **SC-002**: The default unit test command's wall-clock runtime increases by less than 5% after this feature ships, measured on a representative developer machine.
+- **SC-003**: 100% of pull requests opened against the main branch trigger the CI integration job, and a failing integration job blocks merge under the project's branch protection rules.
+- **SC-004**: At least one regression caused by drift between the MCP server and a real Infrahub (schema change, response shape change, SDK behavior change) is detected by the integration suite before reaching a release, demonstrated within the first quarter after rollout.
+- **SC-005**: After an integration test run completes or is interrupted, zero Infrahub-related Docker containers, networks, or volumes created by that run remain on the host (verified by inspection).
+- **SC-006**: A new contributor following the documentation can run the integration suite successfully on their first attempt without assistance, validated by at least one external trial.
+
+## Assumptions
+
+- Docker (or a Docker-compatible container engine) is an acceptable prerequisite for running integration tests; contributors without it can still run unit tests.
+- An official, version-pinned Infrahub container image is available and suitable for use as the system-under-test backend.
+- The MCP server's existing public surface (tools, resources, prompts) is the right boundary for integration assertions; deeper white-box testing of internal modules remains the unit test suite's job.
+- The CI environment used by the project supports Docker-in-Docker or an equivalent mechanism for running container-based integration tests.
+- Write tools remain gated by the existing enablement flag; the integration suite will exercise at least one write tool with that flag enabled in a controlled, isolated environment.
+- Existing pytest-based testing conventions (markers, fixtures, configuration) are the right vehicle for organizing and selecting the integration suite, since the unit suite already uses pytest.
+- Network egress to the container image registry is available in both local-developer and CI environments at test time.

--- a/specs/001-infrahub-testcontainers/tasks.md
+++ b/specs/001-infrahub-testcontainers/tasks.md
@@ -1,0 +1,182 @@
+# Tasks: Infrahub Testcontainers Integration Tests
+
+**Input**: Design documents from `/specs/001-infrahub-testcontainers/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: This feature's deliverable **is** the integration test suite. The test files in Phase 3 ARE the implementation (not a separate test-first layer). Foundational fixtures (Phase 2) are the harness those tests depend on.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+> **Implementation status (2026-06-15)**: MVP (Phases 1–3, T001–T017) implemented; default unit suite verified green (`328 passed, 12 deselected`) and integration tests verified to collect (12 tests, asyncio). The Docker end-to-end run (T018) and Phases 4–6 (US2/US3/Polish) are **not yet done** — see the report. Code written but the live Infrahub container run is deferred.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths are included in each description
+
+## Path Conventions
+
+Single project. Source under `src/infrahub_mcp/`, tests under `tests/` at repo root. New work lives in `tests/integration/`, `pyproject.toml`, `.github/workflows/ci.yml`, and `docs/docs/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add the dependency and configure suite separation so the default loop stays Docker-free.
+
+- [X] T001 Add `infrahub-testcontainers` to the `dev` dependency group in `pyproject.toml`, pinned to a specific minor (e.g. `~=X.Y`), then run `uv sync --all-groups` (research D5; FR-008)
+- [X] T002 In `pyproject.toml` `[tool.pytest.ini_options]`: register the `integration` marker, add default selection `-m "not integration"`, and keep `-p no:pytest-infrahub` for the default run (research D6, spec Clarifications; FR-002, SC-002)
+- [X] T003 [P] Create the integration package skeleton: `tests/integration/__init__.py` and the `tests/integration/fixtures/` directory (plan Project Structure)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The session container, seed data, per-test branch, and in-process MCP client fixtures every integration test depends on.
+
+**⚠️ CRITICAL**: No user-story test (Phase 3+) can run until this phase is complete.
+
+- [X] T004 [P] Create minimal seed schema `tests/integration/fixtures/schema_minimal.yml`, reusing an existing demo shape (e.g. `LocationSite`) so unit and integration fixtures share a mental model (data-model SeedSchema; research D9)
+- [X] T005 [P] Create baseline seed-data loader `tests/integration/fixtures/seed.py` using the Infrahub SDK to create fixed nodes on `main` (data-model SeedNodes; research D9; Constitution II)
+- [X] T006 Implement the session-scoped Infrahub container fixture in `tests/integration/conftest.py` via `infrahub-testcontainers`, with Docker-availability fail-fast and an HTTP readiness probe; rely on the upstream per-session project name + random ports for concurrent-run isolation (data-model IntegrationTestSession; research D1, D10; FR-001, FR-007, FR-009; edge cases: Docker-unavailable, slow-startup, image-pull-failure)
+- [X] T007 Add session seeding (load `schema_minimal.yml`, then `seed.py` nodes on `main`) to `tests/integration/conftest.py`, gated on container readiness (data-model SeedSchema/SeedNodes; research D9; FR-011)
+- [X] T008 Implement the function-scoped per-test Infrahub branch fixture in `tests/integration/conftest.py` (create off `main`, delete in `try/finally`) (data-model PerTestBranch; FR-011, FR-004; Constitution III)
+- [X] T009 Implement the in-process FastMCP `mcp_client` fixture in `tests/integration/conftest.py` using `Client(mcp)` (in-memory transport) with the container Infrahub address + admin token via env, `read_only=false` (data-model McpServerUnderTest; research D2)
+- [X] T010 Implement guaranteed teardown in `tests/integration/conftest.py`: interruption-safe cleanup of containers/networks/volumes and per-test branches, plus the `INFRAHUB_TESTCONTAINERS_KEEP` opt-out toggle (FR-004; research D8; edge case: Ctrl-C/CI-cancel; SC-005)
+
+**Checkpoint**: Harness ready — integration test files can now be authored. ✅
+
+---
+
+## Phase 3: User Story 1 - Validate MCP server against real Infrahub (Priority: P1) 🎯 MVP
+
+**Goal**: A local integration suite that provisions an ephemeral Infrahub, exercises the MCP surface against it, and reports pass/fail with clean teardown.
+
+**Independent Test**: On a machine with Docker, `uv run pytest -m integration` starts an Infrahub container, runs the tests, tears everything down, and prints a clear pass/fail summary.
+
+> The test files below are independent (separate files) and map to the contracts in `contracts/integration-test-surface.md`. All drive the server via the `mcp_client` in-process fixture.
+
+- [X] T011 [P] [US1] `tests/integration/test_schema_resource.py` — read the `infrahub://schema` resource and assert it includes the seeded kind (contract R1; FR-005)
+- [X] T012 [P] [US1] `tests/integration/test_branches_resource.py` — read the `infrahub://branches` resource and assert it includes `main` + the per-test branch, with `main` flagged default (contract R2; FR-005)
+- [X] T013 [P] [US1] `tests/integration/test_node_tools.py` — `get_nodes` list + filter + pagination cases against seeded data (contracts T1, T2; FR-005)
+- [X] T014 [P] [US1] `tests/integration/test_graphql_tool.py` — `query_graphql` read against seeded shape; assert mutations are rejected as MCP-standard errors (contract T3; FR-005; Constitution I, VI)
+- [X] T015 [P] [US1] `tests/integration/test_write_tool.py` — `node_upsert` does not touch `main` (branch-safety); plus a `read_only=true` variant (reloaded server) asserting the write is rejected (contract T4; FR-005; Constitution III, VI)
+- [X] T016 [P] [US1] `tests/integration/test_version_compat.py` — read running Infrahub version, assert MAJOR.MINOR matches the pinned `infrahub-sdk`, emit a distinct `xfail` labeled "version drift" on mismatch (contract V1; FR-013; edge case: version-drift)
+- [X] T017 [P] [US1] `tests/integration/test_failure_modes.py` — F2: malformed tool input rejected by FastMCP schema enforcement; F1 (weaker, non-destructive): bad request surfaces a clean MCP error with no stack trace (contracts F1, F2; FR-012; Constitution VI)
+- [ ] T018 [US1] Verify the full local flow end-to-end via `uv run pytest -m integration`: provisions, runs, tears down with zero residual Docker state, under the 10-minute budget (FR-003, FR-004; SC-001, SC-005; quickstart) — **DEFERRED**: harness verified via `--collect-only` (12 tests) + default unit suite green; the live Docker run is pending (see report's "first-run checklist")
+
+**Checkpoint**: US1 code complete; live validation pending T018.
+
+---
+
+## Phase 4: User Story 2 - Run integration tests in CI (Priority: P2)
+
+**Goal**: CI runs the integration suite on every PR as a distinct, merge-gating check.
+
+**Independent Test**: Open a PR that breaks the MCP↔Infrahub interaction → the CI `integration-tests` job fails and blocks merge.
+
+- [ ] T019 [US2] Add an `integration-tests` job to `.github/workflows/ci.yml`: `ubuntu-latest`, setup uv + Python 3.13, `uv sync --all-groups`, `uv run pytest -m integration --tb=short`, pin `INFRAHUB_TESTING_IMAGE_VER`, reuse the existing `files-changed` path filter (research D4; FR-006, FR-008)
+- [ ] T020 [US2] Ensure the CI job surfaces diagnostic context on failure (failing test name, per-test branch, last ~200 lines of `infrahub-server`/`task-worker` logs) in `.github/workflows/ci.yml` (research D7; FR-012)
+- [ ] T021 [P] [US2] Document the required-check / branch-protection setup that gates merges to `stable` on the `integration-tests` job (research D4; SC-003)
+
+**Checkpoint**: PRs are validated and gated in CI.
+
+---
+
+## Phase 5: User Story 3 - Keep the fast unit loop intact (Priority: P2)
+
+**Goal**: Default `uv run pytest` stays Docker-free and within 5% of its current runtime.
+
+**Independent Test**: Run the default command → only unit tests run, no containers start, runtime ≈ baseline.
+
+- [ ] T022 [P] [US3] Add `tests/unit/test_integration_separation.py` asserting the default pytest selection collects zero `integration`-marked tests (guards FR-002 / no accidental Docker in the fast loop) (FR-002; US3 AC1)
+- [ ] T023 [P] [US3] Measure default `uv run pytest` wall-clock vs the pre-feature baseline, confirm <5% delta, and record the result in `quickstart.md` (SC-002; US3 AC2)
+
+**Checkpoint**: Fast inner loop verified unchanged. (Provisionally confirmed: `1.67s`, 12 deselected.)
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, guidelines, and quality gates spanning all stories.
+
+- [ ] T024 [P] Add a user-facing testing page in `docs/docs/` (Diataxis, `.mdx`) describing the unit vs integration commands and each one's prerequisites (FR-010, SC-006; US3 AC3; Constitution doc requirement)
+- [ ] T025 [P] Capture an integration-testing guideline in `dev/guidelines/` (in-process FastMCP client pattern, branch-per-test isolation, fixture lifecycle) (Constitution doc requirement)
+- [ ] T026 Run `uv run invoke format lint` and resolve all ruff + mypy findings over `tests/integration/` (Constitution IV; quality gate)
+- [ ] T027 Validate `quickstart.md` end-to-end on a clean checkout to confirm first-attempt success (SC-006)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup — **BLOCKS all user stories**.
+- **User Stories (Phase 3–5)**: All depend on Foundational. US1 is the MVP; US2 and US3 depend only on the harness + US1's suite existing (US2 runs it in CI; US3 verifies it stays excluded by default).
+- **Polish (Phase 6)**: Depends on the desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: After Foundational. No dependency on other stories.
+- **US2 (P2)**: After US1's suite exists (CI runs the integration marker). Independently testable via a deliberately-broken PR.
+- **US3 (P2)**: After Setup's marker/addopts (T002); independently testable via the default command. Can proceed in parallel with US1/US2.
+
+### Within Each Story
+
+- Foundational `conftest.py` tasks (T006–T010) are **sequential** — same file.
+- US1 test files (T011–T017) are **parallel** — separate files; T018 depends on all of them.
+- CI tasks (T019–T020) are **sequential** — same `ci.yml` file.
+
+### Parallel Opportunities
+
+- T003 ∥ T001/T002 boundary (different files; T001→T002 sequential on `pyproject.toml`).
+- T004 ∥ T005 (separate fixture files).
+- T011–T017 all parallel (separate test files).
+- T021, T022, T023, T024, T025 are each `[P]` against their peers (distinct files).
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After the Phase 2 harness is in place, author all US1 test files in parallel:
+Task: "tests/integration/test_schema_resource.py (R1)"
+Task: "tests/integration/test_branches_resource.py (R2)"
+Task: "tests/integration/test_node_tools.py (T1, T2)"
+Task: "tests/integration/test_graphql_tool.py (T3)"
+Task: "tests/integration/test_write_tool.py (T4)"
+Task: "tests/integration/test_version_compat.py (V1)"
+Task: "tests/integration/test_failure_modes.py (F1, F2)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1: Setup (T001–T003) ✅
+2. Phase 2: Foundational harness (T004–T010) ✅ — **critical, blocks everything**
+3. Phase 3: US1 test files (T011–T017) ✅ + end-to-end verification (T018, deferred)
+4. **STOP and VALIDATE**: `uv run pytest -m integration` locally — green, clean teardown. *(pending — needs Docker run)*
+
+### Incremental Delivery
+
+1. Setup + Foundational → harness ready
+2. US1 → local integration suite (MVP) → validate
+3. US2 → CI gating → validate via broken-PR test
+4. US3 → confirm fast loop unaffected
+5. Polish → docs, guidelines, lint, quickstart validation
+
+---
+
+## Notes
+
+- The deliverable is tests; Phase 3 files are the product, not a TDD pre-step.
+- [P] = different files, no incomplete dependencies. `conftest.py` and `ci.yml` tasks are intentionally not `[P]` (shared files).
+- Trace IDs (FR-/SC-/contract R#,T#,V#,F#) are in each task for coverage back to spec.md and contracts/.
+- SC-004 (catch a real drift within a quarter) is a post-launch observational outcome, not a buildable task — validated in production, not in this plan.
+- Commit after each task or logical group; keep `tests/unit/` untouched except the T022 separation guard (Phase 5, not yet done).
+- **Implementation deviation**: the harness imports `infrahub_testcontainers` classes directly and does not require the `pytest-infrahub` plugin to be enabled (both infrahub pytest plugins are disabled in `addopts` for all runs). This is simpler than research D6 anticipated; spec FR-002's "plugin enabled for integration" is satisfied-by-not-needed.

--- a/src/infrahub_mcp/server.py
+++ b/src/infrahub_mcp/server.py
@@ -70,7 +70,7 @@ def _validate_env() -> None:
 
 
 @asynccontextmanager
-async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:  # noqa: ARG001, RUF029
+async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:  # noqa: ARG001
     """Manage the application lifecycle: validate config, create client, yield context."""
     _validate_env()
     client = (

--- a/tests/integration/_util.py
+++ b/tests/integration/_util.py
@@ -1,0 +1,29 @@
+"""Small helpers shared by the integration test files."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def tool_text(result: Any) -> str:
+    """Extract a tool call's textual payload across FastMCP result shapes.
+
+    Tools in this server return strings (JSON or TOON-encoded), exposed either as
+    ``result.data`` or as text content blocks.
+    """
+    data = getattr(result, "data", None)
+    if isinstance(data, str):
+        return data
+    content = getattr(result, "content", None) or []
+    return "".join(getattr(block, "text", "") for block in content)
+
+
+def resource_json(contents: Any) -> Any:
+    """Parse a JSON resource read (list of contents) into a Python object."""
+    return json.loads(contents[0].text)
+
+
+def resource_text(contents: Any) -> str:
+    """Return the raw text of a resource read (list of contents)."""
+    return str(contents[0].text)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,208 @@
+"""Fixtures for the Infrahub MCP integration suite.
+
+Design (see specs/001-infrahub-testcontainers/):
+- ONE Infrahub container per pytest session (research D1), provisioned via the
+  upstream ``infrahub-testcontainers`` ``InfrahubDockerCompose`` helper used
+  directly so we can scope it to the *session* (the upstream ``TestInfrahubDocker``
+  fixtures are class-scoped).
+- A fresh Infrahub branch per test for isolation (FR-011), deleted on teardown.
+- The MCP server is driven via the in-process FastMCP ``Client`` (in-memory
+  transport) so the ASGI auth/OIDC layer is bypassed while FastMCP-level
+  middleware (ReadOnly, audit, ...) still runs (research D2).
+
+NOTE: This harness was authored against the verified package APIs but has not
+yet been executed end-to-end (Docker run deferred). Items marked ``RUNTIME``
+below are the assumptions to confirm on the first ``uv run pytest -m integration``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import subprocess  # noqa: S404 - used only for a local `docker info` probe
+import time
+import uuid
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from fastmcp import Client
+from infrahub_sdk import Config, InfrahubClient
+from infrahub_testcontainers import __version__ as testcontainers_version
+from infrahub_testcontainers.container import PROJECT_ENV_VARIABLES, InfrahubDockerCompose
+
+from tests.integration.fixtures.seed import WIDGET_KIND, seed_baseline
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+# Well-known initial admin token shipped by infrahub-testcontainers — a fixed
+# test fixture, never a production secret.
+ADMIN_TOKEN: str = PROJECT_ENV_VARIABLES["INFRAHUB_TESTING_INITIAL_ADMIN_TOKEN"]
+
+#: Set to leave the container running after the suite for inspection (research D8).
+KEEP_ENV = "INFRAHUB_TESTCONTAINERS_KEEP"
+
+#: Max seconds to wait for the Infrahub API to answer after the stack starts.
+READINESS_TIMEOUT_S = 240
+
+
+def _docker_available() -> bool:
+    try:
+        result = subprocess.run(
+            ["docker", "info"],  # noqa: S607 - intentional partial path for a local docker probe
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+async def _wait_until_ready(client: InfrahubClient, timeout_s: int = READINESS_TIMEOUT_S) -> None:
+    """Poll the Infrahub API until it responds, or fail with a clear timeout (FR-007)."""
+    deadline = time.monotonic() + timeout_s
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            await client.get_version()
+        except Exception as exc:  # noqa: BLE001 - readiness probe tolerates any transient error
+            last_error = exc
+            await asyncio.sleep(3)
+        else:
+            return
+    pytest.fail(
+        f"Infrahub API did not become ready within {timeout_s}s: {last_error}",
+        pytrace=False,
+    )
+
+
+def _make_client(address: str) -> InfrahubClient:
+    return InfrahubClient(address=address, config=Config(api_token=ADMIN_TOKEN))
+
+
+@pytest.fixture(scope="session")
+def infrahub_container(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Start one Infrahub stack for the whole session; yield its base address.
+
+    Fails fast (no traceback noise) when Docker is unavailable (FR-007, edge:
+    Docker-unavailable). Tears the stack down on exit unless ``INFRAHUB_TESTCONTAINERS_KEEP``
+    is set (FR-004, edge: Ctrl-C/CI-cancel — pytest finalizers still run).
+    """
+    if not _docker_available():
+        pytest.fail(
+            "Docker engine not reachable — integration tests require Docker. "
+            "See specs/001-infrahub-testcontainers/quickstart.md.",
+            pytrace=False,
+        )
+
+    version = os.getenv("INFRAHUB_TESTING_IMAGE_VER") or testcontainers_version
+    directory = Path(tmp_path_factory.mktemp("infrahub"))
+    compose = InfrahubDockerCompose.init(directory=directory, version=version)
+
+    try:
+        compose.start()
+    except Exception as exc:  # noqa: BLE001 - surface compose logs then fail clearly
+        stdout, stderr = compose.get_logs()
+        pytest.fail(
+            f"Failed to start the Infrahub container (image {version}): {exc}\n"
+            f"--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}",
+            pytrace=False,
+        )
+
+    ports = compose.get_services_port()
+    address = f"http://localhost:{ports['server']}"
+
+    try:
+        yield address
+    finally:
+        if os.getenv(KEEP_ENV):
+            warnings.warn(
+                f"{KEEP_ENV} set — leaving Infrahub stack running at {address}. "
+                "Tear it down manually with `docker compose ls` + `docker compose -p <project> down -v`.",
+                stacklevel=2,
+            )
+        else:
+            compose.stop()
+
+
+@pytest.fixture(scope="session")
+def seeded_infrahub(infrahub_container: str) -> dict[str, object]:
+    """Wait for readiness, seed the baseline schema + widgets once, and point the
+    MCP server at the container via environment variables (read by ``InfrahubClient()``
+    inside the server lifespan, and ``INFRAHUB_MCP_READ_ONLY`` read at server import).
+
+    Returns ``{"address", "widget_kind", "widget_ids"}`` for tests to assert against.
+    """
+
+    async def _prepare() -> dict[str, str]:
+        client = _make_client(infrahub_container)
+        await _wait_until_ready(client)
+        return await seed_baseline(client)
+
+    widget_ids = asyncio.run(_prepare())
+
+    os.environ["INFRAHUB_ADDRESS"] = infrahub_container
+    os.environ["INFRAHUB_API_TOKEN"] = ADMIN_TOKEN
+    os.environ.setdefault("INFRAHUB_MCP_READ_ONLY", "false")
+
+    return {"address": infrahub_container, "widget_kind": WIDGET_KIND, "widget_ids": widget_ids}
+
+
+@pytest.fixture
+def infrahub_client(seeded_infrahub: dict[str, object]) -> InfrahubClient:
+    """A direct SDK client (admin token) for test-side setup/verification."""
+    return _make_client(str(seeded_infrahub["address"]))
+
+
+@pytest.fixture
+async def test_branch(infrahub_client: InfrahubClient) -> AsyncIterator[str]:
+    """Create a fresh Infrahub branch off ``main`` for this test; delete on teardown.
+
+    Isolation unit per FR-011 / Constitution III. ``sync_with_git=False`` keeps
+    branch creation fast (no repository sync).
+    """
+    name = f"test-{uuid.uuid4().hex[:8]}"
+    await infrahub_client.branch.create(branch_name=name, sync_with_git=False)
+    try:
+        yield name
+    finally:
+        await infrahub_client.branch.delete(branch_name=name)
+
+
+@pytest.fixture
+async def mcp_client(seeded_infrahub: dict[str, object]) -> AsyncIterator[Client]:
+    """In-process FastMCP client against the server (write tools enabled).
+
+    The server module is imported lazily *after* ``seeded_infrahub`` has set the
+    Infrahub env vars and ``INFRAHUB_MCP_READ_ONLY=false`` (read at import time).
+    """
+    from infrahub_mcp.server import mcp  # noqa: PLC0415 - import after seeded_infrahub sets env
+
+    async with Client(mcp) as client:
+        yield client
+
+
+@pytest.fixture
+async def mcp_client_readonly(seeded_infrahub: dict[str, object]) -> AsyncIterator[Client]:
+    """In-process FastMCP client with ``read_only=true``.
+
+    RUNTIME: ``read_only`` and write-tool mounting are import-time decisions
+    (server.py:49,94,257), so we set the env var and reload the server module to
+    rebuild ``mcp`` with ``ReadOnlyMiddleware`` attached and write tools unmounted.
+    Confirm reload is clean (module-level FastMCP construction) on first run.
+    """
+    import infrahub_mcp.server as server_mod  # noqa: PLC0415 - reload after toggling read_only env
+
+    previous = os.environ.get("INFRAHUB_MCP_READ_ONLY", "false")
+    os.environ["INFRAHUB_MCP_READ_ONLY"] = "true"
+    importlib.reload(server_mod)
+    try:
+        async with Client(server_mod.mcp) as client:
+            yield client
+    finally:
+        os.environ["INFRAHUB_MCP_READ_ONLY"] = previous
+        importlib.reload(server_mod)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -147,7 +147,9 @@ def seeded_infrahub(infrahub_container: str) -> dict[str, object]:
 
     os.environ["INFRAHUB_ADDRESS"] = infrahub_container
     os.environ["INFRAHUB_API_TOKEN"] = ADMIN_TOKEN
-    os.environ.setdefault("INFRAHUB_MCP_READ_ONLY", "false")
+    # Hard-set (not setdefault): the default mcp_client needs write tools enabled,
+    # so any externally-set INFRAHUB_MCP_READ_ONLY=true must be overridden here.
+    os.environ["INFRAHUB_MCP_READ_ONLY"] = "false"
 
     return {"address": infrahub_container, "widget_kind": WIDGET_KIND, "widget_ids": widget_ids}
 

--- a/tests/integration/fixtures/schema_minimal.yml
+++ b/tests/integration/fixtures/schema_minimal.yml
@@ -9,6 +9,8 @@ nodes:
     label: Widget
     description: Test-only node used by the MCP integration suite.
     default_filter: name__value
+    display_labels:
+      - name__value
     human_friendly_id:
       - name__value
     attributes:

--- a/tests/integration/fixtures/schema_minimal.yml
+++ b/tests/integration/fixtures/schema_minimal.yml
@@ -1,0 +1,23 @@
+# Minimal Infrahub schema for MCP integration tests (FR-011 deterministic baseline).
+# Kept intentionally small — just enough surface to exercise the MCP tools/resources.
+# Kind resolves to "TestingWidget".
+---
+version: "1.0"
+nodes:
+  - name: Widget
+    namespace: Testing
+    label: Widget
+    description: Test-only node used by the MCP integration suite.
+    default_filter: name__value
+    human_friendly_id:
+      - name__value
+    attributes:
+      - name: name
+        kind: Text
+        unique: true
+      - name: color
+        kind: Text
+        optional: true
+      - name: quantity
+        kind: Number
+        optional: true

--- a/tests/integration/fixtures/seed.py
+++ b/tests/integration/fixtures/seed.py
@@ -1,0 +1,54 @@
+"""Deterministic seed data for the MCP integration suite.
+
+Loaded once per session into the ``main`` branch (research D9). Per-test
+branches are created off this baseline so every test starts from a known state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ruamel.yaml import YAML
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+SCHEMA_PATH = Path(__file__).parent / "schema_minimal.yml"
+
+#: Kind exposed by ``schema_minimal.yml`` (namespace ``Testing`` + name ``Widget``).
+WIDGET_KIND = "TestingWidget"
+
+#: Baseline widgets created on ``main``. Two are red / one is blue so the
+#: ``get_nodes`` filter case has a non-trivial result, and three rows let the
+#: pagination case request a partial page.
+SEED_WIDGETS: tuple[dict[str, object], ...] = (
+    {"name": "alpha", "color": "red", "quantity": 1},
+    {"name": "beta", "color": "blue", "quantity": 2},
+    {"name": "gamma", "color": "red", "quantity": 3},
+)
+
+
+def _load_schema_dict() -> dict[str, object]:
+    yaml = YAML(typ="safe")
+    return yaml.load(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+async def load_schema(client: InfrahubClient, *, branch: str = "main") -> None:
+    """Load the minimal test schema and wait for it to converge."""
+    await client.schema.load(schemas=[_load_schema_dict()], branch=branch, wait_until_converged=True)
+
+
+async def seed_baseline(client: InfrahubClient, *, branch: str = "main") -> dict[str, str]:
+    """Load the schema and create the baseline widgets on ``branch``.
+
+    Returns a mapping of widget name -> created node id, so tests can assert
+    against known ids without rediscovering them.
+    """
+    await load_schema(client, branch=branch)
+    created: dict[str, str] = {}
+    for widget in SEED_WIDGETS:
+        node = await client.create(kind=WIDGET_KIND, data=dict(widget), branch=branch)
+        await node.save()
+        created[str(widget["name"])] = str(node.id)
+    return created

--- a/tests/integration/test_branches_resource.py
+++ b/tests/integration/test_branches_resource.py
@@ -1,0 +1,26 @@
+"""Integration: the `infrahub://branches` resource lists main + the per-test branch (contract R2, FR-005)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.integration._util import resource_json
+
+if TYPE_CHECKING:
+    from fastmcp import Client
+
+pytestmark = [pytest.mark.integration]
+
+
+async def test_branches_resource_includes_main_and_test_branch(
+    mcp_client: Client,
+    test_branch: str,
+) -> None:
+    contents = await mcp_client.read_resource("infrahub://branches")
+    branches = resource_json(contents)  # {branch_name: {is_default: bool, description: str}}
+
+    assert "main" in branches
+    assert test_branch in branches
+    assert branches["main"]["is_default"] is True

--- a/tests/integration/test_failure_modes.py
+++ b/tests/integration/test_failure_modes.py
@@ -1,0 +1,41 @@
+"""Integration: cross-cutting failure-mode contracts (F1/F2, FR-012; Constitution VI).
+
+F2 (malformed input rejected by FastMCP schema enforcement before any SDK call) is
+asserted directly. The full F1 scenario (Infrahub torn down mid-suite) is destructive
+to the shared session container, so here we assert the weaker, non-destructive property
+that a bad request surfaces as a clean MCP error with no internal stack trace leaked;
+the full unreachable-backend case is validated manually (see quickstart.md).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from fastmcp.exceptions import ToolError
+from mcp import McpError
+
+from tests.integration._util import tool_text
+
+if TYPE_CHECKING:
+    from fastmcp import Client
+
+pytestmark = [pytest.mark.integration]
+
+
+async def test_malformed_input_rejected_before_sdk_call(mcp_client: Client) -> None:
+    # `get_nodes` requires `kind`; omitting it must be rejected by schema enforcement (F2).
+    with pytest.raises((ToolError, McpError)):
+        await mcp_client.call_tool("get_nodes", {})
+
+
+async def test_bad_request_surfaces_clean_error(mcp_client: Client) -> None:
+    # An unknown kind must surface a clean message, never an internal traceback (F1, Principle VI).
+    # raise_on_error=False so an error result is returned (not raised) for inspection.
+    result = await mcp_client.call_tool(
+        "get_nodes",
+        {"kind": "ThisKindDoesNotExist"},
+        raise_on_error=False,
+    )
+
+    assert "Traceback (most recent call last)" not in tool_text(result)

--- a/tests/integration/test_graphql_tool.py
+++ b/tests/integration/test_graphql_tool.py
@@ -1,0 +1,32 @@
+"""Integration: `query_graphql` reads seeded data and rejects mutations (contract T3, FR-005; Constitution I/VI)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from fastmcp.exceptions import ToolError
+from mcp import McpError
+
+from tests.integration._util import tool_text
+
+if TYPE_CHECKING:
+    from fastmcp import Client
+
+pytestmark = [pytest.mark.integration]
+
+_WIDGET_QUERY = "query { TestingWidget { edges { node { name { value } } } } }"
+_MUTATION = 'mutation { CoreAccountCreate(data: {name: {value: "x"}}) { ok } }'
+
+
+async def test_query_graphql_reads_seeded_data(mcp_client: Client) -> None:
+    result = await mcp_client.call_tool("query_graphql", {"query": _WIDGET_QUERY})
+
+    assert not result.is_error
+    assert "alpha" in tool_text(result)
+
+
+async def test_query_graphql_rejects_mutation(mcp_client: Client) -> None:
+    # The read-only GraphQL tool rejects mutations via AST inspection (OperationType.MUTATION).
+    with pytest.raises((ToolError, McpError)):
+        await mcp_client.call_tool("query_graphql", {"query": _MUTATION})

--- a/tests/integration/test_node_tools.py
+++ b/tests/integration/test_node_tools.py
@@ -1,0 +1,59 @@
+"""Integration: node read tools `get_nodes` — list, filter, pagination (contracts T1/T2, FR-005)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.integration._util import tool_text
+
+if TYPE_CHECKING:
+    from fastmcp import Client
+
+pytestmark = [pytest.mark.integration]
+
+
+async def test_get_nodes_returns_seeded_widgets(
+    mcp_client: Client,
+    seeded_infrahub: dict[str, object],
+) -> None:
+    result = await mcp_client.call_tool("get_nodes", {"kind": seeded_infrahub["widget_kind"]})
+
+    assert not result.is_error
+    text = tool_text(result)
+    assert "alpha" in text
+    assert "gamma" in text
+
+
+async def test_get_nodes_filter_by_color(
+    mcp_client: Client,
+    seeded_infrahub: dict[str, object],
+) -> None:
+    # NOTE(runtime): confirm the tool forwards `filters` to the SDK as `<attr>__value`.
+    result = await mcp_client.call_tool(
+        "get_nodes",
+        {"kind": seeded_infrahub["widget_kind"], "filters": {"color__value": "blue"}},
+    )
+
+    assert not result.is_error
+    text = tool_text(result)
+    assert "beta" in text  # the only blue widget
+    assert "alpha" not in text
+
+
+async def test_get_nodes_pagination_limits_page_size(
+    mcp_client: Client,
+    seeded_infrahub: dict[str, object],
+) -> None:
+    # Three widgets are seeded; a limit of 2 must return a partial first page.
+    # NOTE(runtime): confirm pagination metadata shape to assert "has next page".
+    page = await mcp_client.call_tool(
+        "get_nodes",
+        {"kind": seeded_infrahub["widget_kind"], "limit": 2},
+    )
+
+    assert not page.is_error
+    text = tool_text(page)
+    present = [name for name in ("alpha", "beta", "gamma") if name in text]
+    assert len(present) == 2

--- a/tests/integration/test_schema_resource.py
+++ b/tests/integration/test_schema_resource.py
@@ -1,0 +1,24 @@
+"""Integration: the `infrahub://schema` resource reflects the seeded schema (contract R1, FR-005)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.integration._util import resource_json
+
+if TYPE_CHECKING:
+    from fastmcp import Client
+
+pytestmark = [pytest.mark.integration]
+
+
+async def test_schema_resource_lists_seeded_kind(
+    mcp_client: Client,
+    seeded_infrahub: dict[str, object],
+) -> None:
+    contents = await mcp_client.read_resource("infrahub://schema")
+    catalog = resource_json(contents)  # {kind_name: human_label}
+
+    assert seeded_infrahub["widget_kind"] in catalog

--- a/tests/integration/test_version_compat.py
+++ b/tests/integration/test_version_compat.py
@@ -1,16 +1,23 @@
-"""Integration: Infrahub version-compatibility check (contract V1, FR-013; "version drift" edge case).
+"""Integration: Infrahub version-compatibility check (contract V1, FR-013).
 
-Emits a distinct, clearly-labeled result (xfail) when the running Infrahub version
-diverges from the version the pinned infrahub-sdk targets — so version drift is
-never confused with a functional product regression.
+Asserts the running Infrahub server matches the container image the test harness
+actually launched — ``INFRAHUB_TESTING_IMAGE_VER`` when set, otherwise the
+``infrahub-testcontainers`` package version that pins the default image (mirrors
+the resolution in ``conftest.py``).
+
+This guards a real, controllable invariant — that we exercised the server version
+we intended to — rather than the ``infrahub-sdk`` package version, which tracks
+independently of the Infrahub server release line (SDK 1.20.x vs server 1.10.x)
+and so would never match.
 """
 
 from __future__ import annotations
 
-from importlib.metadata import version as pkg_version
+import os
 from typing import TYPE_CHECKING
 
 import pytest
+from infrahub_testcontainers import __version__ as testcontainers_version
 
 if TYPE_CHECKING:
     from infrahub_sdk import InfrahubClient
@@ -23,15 +30,13 @@ def _minor(version: str) -> str:
     return ".".join(version.lstrip("v").split(".")[:2])
 
 
-async def test_running_infrahub_matches_sdk_version(infrahub_client: InfrahubClient) -> None:
+async def test_running_infrahub_matches_launched_image(infrahub_client: InfrahubClient) -> None:
     running = await infrahub_client.get_version()
-    sdk = pkg_version("infrahub-sdk")
+    # The image the harness launched: explicit override, else the infrahub-testcontainers
+    # package version — the exact resolution conftest.py uses to pick the image tag.
+    expected = os.getenv("INFRAHUB_TESTING_IMAGE_VER") or testcontainers_version
 
-    # NOTE(runtime): "supported range" heuristic = matching MAJOR.MINOR (research D11).
-    if _minor(running) != _minor(sdk):
-        pytest.xfail(
-            f"Infrahub version drift: running Infrahub {running} vs infrahub-sdk {sdk} "
-            "(version drift, NOT a product regression — reconcile the pinned versions)."
-        )
-
-    assert _minor(running) == _minor(sdk)
+    assert _minor(running) == _minor(expected), (
+        f"Running Infrahub {running} does not match the launched image {expected} "
+        "(MAJOR.MINOR mismatch — the container did not start at the requested version)."
+    )

--- a/tests/integration/test_version_compat.py
+++ b/tests/integration/test_version_compat.py
@@ -1,0 +1,37 @@
+"""Integration: Infrahub version-compatibility check (contract V1, FR-013; "version drift" edge case).
+
+Emits a distinct, clearly-labeled result (xfail) when the running Infrahub version
+diverges from the version the pinned infrahub-sdk targets — so version drift is
+never confused with a functional product regression.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version as pkg_version
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from infrahub_sdk import InfrahubClient
+
+pytestmark = [pytest.mark.integration]
+
+
+def _minor(version: str) -> str:
+    """Return the MAJOR.MINOR prefix of a version string."""
+    return ".".join(version.lstrip("v").split(".")[:2])
+
+
+async def test_running_infrahub_matches_sdk_version(infrahub_client: InfrahubClient) -> None:
+    running = await infrahub_client.get_version()
+    sdk = pkg_version("infrahub-sdk")
+
+    # NOTE(runtime): "supported range" heuristic = matching MAJOR.MINOR (research D11).
+    if _minor(running) != _minor(sdk):
+        pytest.xfail(
+            f"Infrahub version drift: running Infrahub {running} vs infrahub-sdk {sdk} "
+            "(version drift, NOT a product regression — reconcile the pinned versions)."
+        )
+
+    assert _minor(running) == _minor(sdk)

--- a/tests/integration/test_write_tool.py
+++ b/tests/integration/test_write_tool.py
@@ -1,0 +1,46 @@
+"""Integration: a representative write tool — branch isolation + read-only gating (contract T4, FR-005; Constitution III/VI)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from fastmcp.exceptions import ToolError
+from mcp import McpError
+
+if TYPE_CHECKING:
+    from fastmcp import Client
+    from infrahub_sdk import InfrahubClient
+
+pytestmark = [pytest.mark.integration]
+
+
+async def test_node_upsert_does_not_touch_main(
+    mcp_client: Client,
+    infrahub_client: InfrahubClient,
+    seeded_infrahub: dict[str, object],
+) -> None:
+    kind = str(seeded_infrahub["widget_kind"])
+
+    result = await mcp_client.call_tool(
+        "node_upsert",
+        {"kind": kind, "data": {"name": "delta", "color": "green"}},
+    )
+    assert not result.is_error
+
+    # Branch-safety (Principle III): the write lands on the server's session branch,
+    # NOT on main. NOTE(runtime): confirm node_upsert's session-branch behavior + result shape.
+    on_main = await infrahub_client.filters(kind=kind, name__value="delta", branch="main")
+    assert on_main == []
+
+
+async def test_write_tool_blocked_in_read_only(mcp_client_readonly: Client) -> None:
+    kind = "TestingWidget"
+
+    # With read_only=true, write tools are unmounted and ReadOnlyMiddleware blocks the
+    # call — either way the in-process client raises rather than mutating data.
+    with pytest.raises((ToolError, McpError)):
+        await mcp_client_readonly.call_tool(
+            "node_upsert",
+            {"kind": kind, "data": {"name": "epsilon", "color": "black"}},
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,15 @@ wheels = [
 ]
 
 [[package]]
+name = "amplitude-analytics"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/f7/b23d28b1c405c22a25375e2c638c8cdcd054cbc4b43b76cf77bd358a0540/amplitude_analytics-1.2.3.tar.gz", hash = "sha256:4c9525847c391c19675d6e026f4601c27204ffeec71cb92252770d84d4538404", size = 22413, upload-time = "2026-03-31T18:33:20.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/56/83af6ef6a8bac9fdf2059de0276008e9eab40a315b8b732eba466bf6cc74/amplitude_analytics-1.2.3-py3-none-any.whl", hash = "sha256:ba2092c1d37ce8a2e3f69d023da145f4e322d02429e20436a5227178b1e594e9", size = 24762, upload-time = "2026-03-31T18:33:19.032Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -739,7 +748,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "infrahub-testcontainers", specifier = ">=1.9.8" },
+    { name = "infrahub-testcontainers", specifier = ">=1.10.0" },
     { name = "invoke", specifier = ">=2.2.0,<3.0.0" },
     { name = "mypy", specifier = ">=1.17.0" },
     { name = "pylint", specifier = ">=4.0.5" },
@@ -772,7 +781,7 @@ wheels = [
 
 [[package]]
 name = "infrahub-testcontainers"
-version = "1.9.8"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -782,9 +791,9 @@ dependencies = [
     { name = "pytest" },
     { name = "testcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/24/e3be5eb74e157d6944c4f97eb009a4a44d83c16b91127a21d50859015548/infrahub_testcontainers-1.9.8.tar.gz", hash = "sha256:ebfdd5a163e97cca9b9ec24c89f4e6d4bab7b111643f3b210bde73c4b48d7463", size = 17380, upload-time = "2026-06-09T17:08:51.194Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/5e/783de438ed2e7decfefd18dc99c57b8c7fa2f1e523267813274f373f9c6f/infrahub_testcontainers-1.10.0.tar.gz", hash = "sha256:a91c6cc483c6d5b6604d33faab5ad31d0c3812de530b01a1f3a072e0aa68801d", size = 17933, upload-time = "2026-06-24T11:21:43.02Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/72/0cd541ff20074b3c179a8232162910946a3685f3035b06e6edfa8e11b6a2/infrahub_testcontainers-1.9.8-py3-none-any.whl", hash = "sha256:31da6008c0a5f4ffc8cf386210f012f83095ff3d189bd234f16853e7a6056da7", size = 23220, upload-time = "2026-06-09T17:08:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a6/2ee4bc0e8380234723f7c06649dedcc26d8f086c727530f315c23caed74a/infrahub_testcontainers-1.10.0-py3-none-any.whl", hash = "sha256:383fa7bf4c717461522ccaf024350def78b9a31316dc862c22cd394849153e25", size = 24211, upload-time = "2026-06-24T11:21:43.943Z" },
 ]
 
 [[package]]
@@ -1221,9 +1230,10 @@ wheels = [
 
 [[package]]
 name = "prefect-client"
-version = "3.6.13"
+version = "3.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "amplitude-analytics" },
     { name = "anyio" },
     { name = "asgi-lifespan" },
     { name = "cachetools" },
@@ -1258,15 +1268,16 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
     { name = "sniffio" },
+    { name = "starlette" },
     { name = "toml" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
     { name = "websockets" },
     { name = "whenever" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/a9/5bfc95aee6ca8e202b7f4235e7e2dcb61a29e62e4b1e2f9eef3163883e6e/prefect_client-3.6.13.tar.gz", hash = "sha256:9f3ceb2771c9f6bffa7c8ec01f625ed27c2c7743e69b42d845311a55da8b3d60", size = 728904, upload-time = "2026-01-23T04:17:50.173Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/6a/bb032829c0f049b3c368a2e673f6eeda4b895080c185e3a750ce0edc5e89/prefect_client-3.7.4.tar.gz", hash = "sha256:2bc0913439c2ef1f614d1899bc30660924846f58448e23a044165ba591d0bcd5", size = 909617, upload-time = "2026-06-05T17:51:44.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/51/0216ef9c7ca6002e7b5ae92cdb2858e4f8c5d69c7f2a4a9050afc1086934/prefect_client-3.6.13-py3-none-any.whl", hash = "sha256:3076194ec12b3770e53b1cb8f1d68a7628b8658912e183431a398d7e1617570d", size = 899733, upload-time = "2026-01-23T04:17:47.825Z" },
+    { url = "https://files.pythonhosted.org/packages/77/73/919e73a47b364dfb01375df7d9e35b74d2cb612c653b69facde8c0184325/prefect_client-3.7.4-py3-none-any.whl", hash = "sha256:1b71fd1266fd8c6e6a1dec5e0f1f6efc633a57bbc60a7f1e313b0895add65876", size = 1124697, upload-time = "2026-06-05T17:51:41.926Z" },
 ]
 
 [[package]]
@@ -1934,14 +1945,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -54,6 +63,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
+]
+
+[[package]]
+name = "asgi-lifespan"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/da/e7908b54e0f8043725a990bf625f2041ecf6bfe8eb7b19407f1c00b630f7/asgi-lifespan-2.1.0.tar.gz", hash = "sha256:5e2effaf0bfe39829cf2d64e7ecc47c7d86d676a6599f7afba378c31f5e3a308", size = 15627, upload-time = "2023-03-28T17:35:49.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/f5/c36551e93acba41a59939ae6a0fb77ddb3f2e8e8caa716410c65f7341f72/asgi_lifespan-2.1.0-py3-none-any.whl", hash = "sha256:ed840706680e28428c01e14afb3875d7d76d3206f3d5b2f2294e059b5c23804f", size = 10895, upload-time = "2023-03-28T17:35:47.772Z" },
 ]
 
 [[package]]
@@ -257,12 +278,30 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coolname"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/c6/1eaa4495ff4640e80d9af64f540e427ba1596a20f735d4c4750fe0386d07/coolname-2.2.0.tar.gz", hash = "sha256:6c5d5731759104479e7ca195a9b64f7900ac5bead40183c09323c7d0be9e75c7", size = 59006, upload-time = "2023-01-09T14:50:41.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/b1/5745d7523d8ce53b87779f46ef6cf5c5c342997939c2fe967e607b944e43/coolname-2.2.0-py2.py3-none-any.whl", hash = "sha256:4d1563186cfaf71b394d5df4c744f8c41303b6846413645e31d31915cdeb13e8", size = 37849, upload-time = "2023-01-09T14:50:39.897Z" },
 ]
 
 [[package]]
@@ -334,6 +373,21 @@ wheels = [
 ]
 
 [[package]]
+name = "dateparser"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/f4/561c49bca97af561d34eed27e3e831135eb5cb88e754c1150be41820f5c6/dateparser-1.4.1.tar.gz", hash = "sha256:f265df13c0380e2e07543ba74b67c0681aaa1096981ffcd35227e1aa0cb81c7c", size = 314734, upload-time = "2026-06-15T08:45:47.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/7c/2e5dcf53909deddd0bf38cbe277ad9806be038276b1c6c436561b4d9b2e2/dateparser-1.4.1-py3-none-any.whl", hash = "sha256:f25d4e051a84be27a35bd297e3e1dc59ff78373701b89be352ba80372d22d0d0", size = 300503, upload-time = "2026-06-15T08:45:45.951Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -349,6 +403,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -426,6 +494,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.137.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b1/e5b92c59d2c37817e77c1a8c2fc1f79cdcc04c68253e5406b43e3204cba7/fastapi-0.137.1.tar.gz", hash = "sha256:822360704230d9533d8d9475399613525968aa2f0b5bd2a3ccc9f18c88fd541c", size = 408293, upload-time = "2026-06-15T11:28:20.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/380b9a5922f4340e51c309cde09e5bd32e62f02302971bee30dc15aa0624/fastapi-0.137.1-py3-none-any.whl", hash = "sha256:64f6983c59e45c4b9fdc44e57cb8035c2451ee91ea8e8ec042aca37de7cf6b69", size = 121877, upload-time = "2026-06-15T11:28:19.523Z" },
+]
+
+[[package]]
 name = "fastmcp"
 version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -459,12 +543,42 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
 name = "graphql-core"
 version = "3.2.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c4/16/7574029da84834349b60ed71614d66ca3afe46e9bf9c7b9562102acb7d4f/graphql_core-3.2.6.tar.gz", hash = "sha256:c08eec22f9e40f0bd61d805907e3b3b1b9a320bc606e23dc145eebca07c8fbab", size = 505353, upload-time = "2025-01-26T16:36:27.374Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/4f/7297663840621022bc73c22d7d9d80dbc78b4db6297f764b545cd5dd462d/graphql_core-3.2.6-py3-none-any.whl", hash = "sha256:78b016718c161a6fb20a7d97bbf107f331cd1afe53e45566c59f776ed7f0b45f", size = 203416, upload-time = "2025-01-26T16:36:24.868Z" },
+]
+
+[[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
 ]
 
 [[package]]
@@ -483,6 +597,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -513,6 +649,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.1"
@@ -520,6 +661,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6e/fa/66bd985dd0b7c109a3bcb89272ee0bfb7e2b4d06309ad7b38ff866734b2a/httpx_sse-0.4.1.tar.gz", hash = "sha256:8f44d34414bc7b21bf3602713005c5df4917884f76072479b21f68befa4ea26e", size = 12998, upload-time = "2025-06-24T13:21:05.71Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/0a/6269e3473b09aed2dab8aa1a600c70f31f00ae1349bee30658f7e358a159/httpx_sse-0.4.1-py3-none-any.whl", hash = "sha256:cba42174344c3a5b06f255ce65b350880f962d99ead85e776f23c6618a377a37", size = 8054, upload-time = "2025-06-24T13:21:04.772Z" },
+]
+
+[[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -557,6 +716,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "infrahub-testcontainers" },
     { name = "invoke" },
     { name = "mypy" },
     { name = "pylint" },
@@ -579,6 +739,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "infrahub-testcontainers", specifier = ">=1.9.8" },
     { name = "invoke", specifier = ">=2.2.0,<3.0.0" },
     { name = "mypy", specifier = ">=1.17.0" },
     { name = "pylint", specifier = ">=4.0.5" },
@@ -607,6 +768,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/29/7b/403c9cf80edec45c347541461a05a363fd5caf63915bfaa418cd148cf044/infrahub_sdk-1.20.0.tar.gz", hash = "sha256:70756bbdaf8dd14de7b270af01cea7861bb65baa513f7b87cf2a58d00cea4b78", size = 976371, upload-time = "2026-04-24T19:26:19.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/ba/0633d5b4b0add03997bffc4f9077a50b5325d2db3ad0e771d93d39967492/infrahub_sdk-1.20.0-py3-none-any.whl", hash = "sha256:a7fb6ed61228e59edcebbf79132b0c038ff3508188ef5bf5134808e47564804e", size = 239300, upload-time = "2026-04-24T19:26:17.444Z" },
+]
+
+[[package]]
+name = "infrahub-testcontainers"
+version = "1.9.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "prefect-client" },
+    { name = "psutil" },
+    { name = "pydantic" },
+    { name = "pytest" },
+    { name = "testcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/24/e3be5eb74e157d6944c4f97eb009a4a44d83c16b91127a21d50859015548/infrahub_testcontainers-1.9.8.tar.gz", hash = "sha256:ebfdd5a163e97cca9b9ec24c89f4e6d4bab7b111643f3b210bde73c4b48d7463", size = 17380, upload-time = "2026-06-09T17:08:51.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/72/0cd541ff20074b3c179a8232162910946a3685f3035b06e6edfa8e11b6a2/infrahub_testcontainers-1.9.8-py3-none-any.whl", hash = "sha256:31da6008c0a5f4ffc8cf386210f012f83095ff3d189bd234f16853e7a6056da7", size = 23220, upload-time = "2026-06-09T17:08:50.14Z" },
 ]
 
 [[package]]
@@ -676,6 +854,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
 ]
 
 [[package]]
@@ -938,6 +1137,44 @@ wheels = [
 ]
 
 [[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/33/93fcc25907235c344ae73122f8a4e01d2d393ef062b4af7d2e2487a32c37/orjson-3.11.9-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021", size = 228458, upload-time = "2026-05-06T15:10:20.079Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/27/b1e6dadb3c080313c03fdd8067b85e6a0460c7d8d6a1c3984ef77b904e4d/orjson-3.11.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:844417969855fc7a41be124aafe83dc424592a7f77cd4501900c67307122b92c", size = 128368, upload-time = "2026-05-06T15:10:21.549Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0f/c9ede0bf052f6b4051e64a7d4fa91b725cccf8321a6a786e86eb03519f00/orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81", size = 132070, upload-time = "2026-05-06T15:10:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/26/d398e28048dc18205bbe812f2c88cb9b40313db2470778e25964796458fe/orjson-3.11.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e4eed3b200023042814d2fc8a5d2e880f13b52e1ed2485e83da4f3962f7dc1a", size = 127892, upload-time = "2026-05-06T15:10:24.714Z" },
+    { url = "https://files.pythonhosted.org/packages/66/60/52b0054c4c700d5aa7fc5b7ca96917400d8f061307778578e67a10e25852/orjson-3.11.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aff7da9952a5ad1cef8e68017724d96c7b9a66e99e91d6252e1b133d67a7b10", size = 135217, upload-time = "2026-05-06T15:10:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/97/1e3dc2b2a28b7b2528f403d2fc1d79ec5f39af3bc143ab65d3ec26426385/orjson-3.11.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d4e98d6f3b8afed8bc8cd9718ec0cdf46661826beefb53fe8eafb37f2bf0362", size = 145980, upload-time = "2026-05-06T15:10:28.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/39/31fbfe7850f2de32dee7e7e5c09f26d403ab01e440ac96001c6b01ad3c99/orjson-3.11.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a81d52442a7c99b3662333235b3adf96a1715864658b35bb797212be7bddb97", size = 132738, upload-time = "2026-05-06T15:10:29.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218", size = 134033, upload-time = "2026-05-06T15:10:31.152Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d4/5bdb0626801230139987385554c5d4c42255218ac906525bf4347f22cd95/orjson-3.11.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fd66214623f1b17501df9f0543bef0b833979ab5b6ded1e1d123222866aa8c9", size = 141492, upload-time = "2026-05-06T15:10:32.641Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/88/a21fb53b3ede6703aede6dce4710ed4111e5b201cfa6bbff5e544f9d47d7/orjson-3.11.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8ecc30f10465fa1e0ce13fd01d9e22c316e5053a719a8d915d4545a09a5ff677", size = 415087, upload-time = "2026-05-06T15:10:34.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/57/1b30daf70f0d8180e9a73cefbfbdd99e4bf19eb020466502b01fba7e0e50/orjson-3.11.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:97db4c94a7db398a5bd636273324f0b3fd58b350bbbac8bb380ceb825a9b40f4", size = 148031, upload-time = "2026-05-06T15:10:36.358Z" },
+    { url = "https://files.pythonhosted.org/packages/04/83/45fbb6d962e260807f99441db9613cee868ceda4baceda59b3720a563f97/orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0", size = 136915, upload-time = "2026-05-06T15:10:38.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/cc/2d10025f9056d376e4127ec05a5808b218d46f035fdc08178a5411b34250/orjson-3.11.9-cp313-cp313-win32.whl", hash = "sha256:d4087e5c0209a0a8efe4de3303c234b9c44d1174161dcd851e8eea07c7560b32", size = 131613, upload-time = "2026-05-06T15:10:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/2775ff28bfe883b9aa1ff348300542eb2ef1ee18d8ae0e3a49846817a865/orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979", size = 127086, upload-time = "2026-05-06T15:10:41.262Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/d26799e580939e32a7da9a39531bc9e58e15ca32ffaa6a8cb3e9bb0d22cd/orjson-3.11.9-cp313-cp313-win_arm64.whl", hash = "sha256:cce9127885941bd28f080cecf1f1d288336b7e0d812c345b08be88b572796254", size = 126696, upload-time = "2026-05-06T15:10:42.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/eb/5da01e356015aee6ecfa1187ced87aef51364e306f5e695dd52719bf0e78/orjson-3.11.9-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:b6ef1979adc4bc243523f1a2ba91418030a8e29b0a99cbe7e0e2d6807d4dce6e", size = 228465, upload-time = "2026-05-06T15:10:44.097Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/3e0e0c14c957133bcd855395c62b55ed4e3b0af23ffea11b032cb1dcbdb1/orjson-3.11.9-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:f36b7f32c7c0db4a719f1fc5824db4a9c6f8bd1a354debb91faf26ebf3a4c71e", size = 128364, upload-time = "2026-05-06T15:10:45.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5a/07d8aa117211a8ed7630bda80c8c0b14d04e0f8dcf99bcf49656e4a710eb/orjson-3.11.9-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08f4d8ebb44925c794e535b2bebc507cebf32209df81de22ae285fb0d8d66de0", size = 132063, upload-time = "2026-05-06T15:10:47.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ec/4acaf21483e18aa945be74a474c74b434f284b549f275a0a39b9f98956e9/orjson-3.11.9-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6cc7923789694fd58f001cbcac7e47abc13af4d560ebbfcf3b41a8b1a0748124", size = 122356, upload-time = "2026-05-06T15:10:48.765Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d8/5f0555e7638801323b7a75850f92e7dfa891bc84fe27a1ba4449170d1200/orjson-3.11.9-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea5c46eb2d3af39e806b986f4b09d5c2706a1f5afde3cbf7544ce6616127173c", size = 129592, upload-time = "2026-05-06T15:10:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/30/ed9860412a3603ceb3c5955bfd72d28b9d0e7ba6ed81add14f83d7114236/orjson-3.11.9-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5d89a2ed90731df3be64bab0aa44f78bff39fdc9d71c291f4a8023aa46425b7", size = 140491, upload-time = "2026-05-06T15:10:51.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/17/adc514dea7ac7c505527febf884934b815d34f0c7b8693c1a8b39c5c4a57/orjson-3.11.9-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25e4aed0312d292c09f61af25bba34e0b2c88546041472b09088c39a4d828af1", size = 127309, upload-time = "2026-05-06T15:10:53.329Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3e/c0b690253f0b82d86e99949af13533363acfb5432ecb5d53dd5b3bce9c34/orjson-3.11.9-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aaea64f3f467d22e70eeed68bdccb3bc4f83f650446c4a03c59f2cba28a108db", size = 134030, upload-time = "2026-05-06T15:10:54.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/7a/bc82a0bb25e9faaf92dc4d9ef002732efc09737706af83e346788641d4a7/orjson-3.11.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a028425d1b440c5d92a6be1e1a020739dfe67ea87d96c6dbe828c1b30041728b", size = 141482, upload-time = "2026-05-06T15:10:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/01/55/e69188b939f77d5d32a9833745ace31ea5ccae3ab613a1ec185d3cd2c4fb/orjson-3.11.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5b192c6cf397e4455b11523c5cf2b18ed084c1bbd61b6c0926344d2129481972", size = 415178, upload-time = "2026-05-06T15:10:58.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/b8a5a7ac527e80b9cb11d51e3f6689b709279183264b9ec5c7bc680bb8b5/orjson-3.11.9-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea407d4ccf5891d667d045fecae97a7a1e5e87b3b97f97ae1803c2e741130be0", size = 148089, upload-time = "2026-05-06T15:11:00.441Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4e/00503f64204bf859b37213a63927028f30fb6268cd8677fb0a5ad48155e1/orjson-3.11.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f63aaf97afd9f6dec5b1a68e1b8da12bfccb4cb9a9a65c3e0b6c847849e7586", size = 136921, upload-time = "2026-05-06T15:11:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ba/a23b82a0a8d0ed7bed4e5f5035aae751cad4ff6a1e8d2ecd14d8860f5929/orjson-3.11.9-cp314-cp314-win32.whl", hash = "sha256:e30ab17845bb9fa54ccf67fa4f9f5282652d54faa6d17452f47d0f369d038673", size = 131638, upload-time = "2026-05-06T15:11:03.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/0c6798456bade745c75c452342dabacce5798196483e77e643be1f53877d/orjson-3.11.9-cp314-cp314-win_amd64.whl", hash = "sha256:32ef5f4283a3be81913947d19608eacb7c6608026851123790cd9cc8982af34b", size = 127078, upload-time = "2026-05-06T15:11:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/16/21/5a3f1e8913103b703a436a5664238e5b965ec392b555fe68943ea3691e6b/orjson-3.11.9-cp314-cp314-win_arm64.whl", hash = "sha256:eebdbdeef0094e4f5aefa20dcd4eb2368ab5e7a3b4edea27f1e7b2892e009cf9", size = 126687, upload-time = "2026-05-06T15:11:06.602Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -980,6 +1217,93 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prefect-client"
+version = "3.6.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "asgi-lifespan" },
+    { name = "cachetools" },
+    { name = "cloudpickle" },
+    { name = "coolname" },
+    { name = "dateparser" },
+    { name = "exceptiongroup" },
+    { name = "fastapi" },
+    { name = "fsspec" },
+    { name = "graphviz" },
+    { name = "griffe" },
+    { name = "httpcore" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "humanize" },
+    { name = "jsonpatch" },
+    { name = "jsonschema" },
+    { name = "opentelemetry-api" },
+    { name = "orjson" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "prometheus-client" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
+    { name = "python-dateutil" },
+    { name = "python-slugify" },
+    { name = "pytz" },
+    { name = "pyyaml" },
+    { name = "rfc3339-validator" },
+    { name = "rich" },
+    { name = "ruamel-yaml" },
+    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "sniffio" },
+    { name = "toml" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+    { name = "whenever" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/a9/5bfc95aee6ca8e202b7f4235e7e2dcb61a29e62e4b1e2f9eef3163883e6e/prefect_client-3.6.13.tar.gz", hash = "sha256:9f3ceb2771c9f6bffa7c8ec01f625ed27c2c7743e69b42d845311a55da8b3d60", size = 728904, upload-time = "2026-01-23T04:17:50.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/51/0216ef9c7ca6002e7b5ae92cdb2858e4f8c5d69c7f2a4a9050afc1086934/prefect_client-3.6.13-py3-none-any.whl", hash = "sha256:3076194ec12b3770e53b1cb8f1d68a7628b8658912e183431a398d7e1617570d", size = 899733, upload-time = "2026-01-23T04:17:47.825Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1093,6 +1417,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-extra-types"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
+]
+
+[[package]]
 name = "pydantic-settings"
 version = "2.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1182,6 +1519,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1197,6 +1546,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
 ]
 
 [[package]]
@@ -1339,6 +1709,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1431,6 +1813,43 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/5e/2f970ce4c573dc30c2f95825f2691c96d55560268ddc67603dc6ea2dd08e/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dcec721fddbb62e60c2801ba08c87010bd6b700054a09998c4d09c08147b8fb", size = 147450, upload-time = "2025-11-16T16:13:33.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/03/a1baa5b94f71383913f21b96172fb3a2eb5576a4637729adbf7cd9f797f8/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:65f48245279f9bb301d1276f9679b82e4c080a1ae25e679f682ac62446fac471", size = 133139, upload-time = "2025-11-16T16:13:34.587Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/19/40d676802390f85784235a05788fd28940923382e3f8b943d25febbb98b7/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46895c17ead5e22bea5e576f1db7e41cb273e8d062c04a6a49013d9f60996c25", size = 731474, upload-time = "2025-11-16T20:22:49.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bb/6ef5abfa43b48dd55c30d53e997f8f978722f02add61efba31380d73e42e/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3eb199178b08956e5be6288ee0b05b2fb0b5c1f309725ad25d9c6ea7e27f962a", size = 748047, upload-time = "2025-11-16T16:13:35.633Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/5d/e4f84c9c448613e12bd62e90b23aa127ea4c46b697f3d760acc32cb94f25/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d1032919280ebc04a80e4fb1e93f7a738129857eaec9448310e638c8bccefcf", size = 782129, upload-time = "2025-11-16T16:13:36.781Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4b/e98086e88f76c00c88a6bcf15eae27a1454f661a9eb72b111e6bbb69024d/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab0df0648d86a7ecbd9c632e8f8d6b21bb21b5fc9d9e095c796cacf32a728d2d", size = 736848, upload-time = "2025-11-16T16:13:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5c/5964fcd1fd9acc53b7a3a5d9a05ea4f95ead9495d980003a557deb9769c7/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:331fb180858dd8534f0e61aa243b944f25e73a4dae9962bd44c46d1761126bbf", size = 741630, upload-time = "2025-11-16T20:22:51.718Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1e/99660f5a30fceb58494598e7d15df883a07292346ef5696f0c0ae5dee8c6/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51", size = 766619, upload-time = "2025-11-16T16:13:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2f/fa0344a9327b58b54970e56a27b32416ffbcfe4dcc0700605516708579b2/ruamel_yaml_clib-0.2.15-cp313-cp313-win32.whl", hash = "sha256:bf0846d629e160223805db9fe8cc7aec16aaa11a07310c50c8c7164efa440aec", size = 100171, upload-time = "2025-11-16T16:13:40.456Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c4/c124fbcef0684fcf3c9b72374c2a8c35c94464d8694c50f37eef27f5a145/ruamel_yaml_clib-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:45702dfbea1420ba3450bb3dd9a80b33f0badd57539c6aac09f42584303e0db6", size = 118845, upload-time = "2025-11-16T16:13:41.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/bd/ab8459c8bb759c14a146990bf07f632c1cbec0910d4853feeee4be2ab8bb/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:753faf20b3a5906faf1fc50e4ddb8c074cb9b251e00b14c18b28492f933ac8ef", size = 147248, upload-time = "2025-11-16T16:13:42.872Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f2/c4cec0a30f1955510fde498aac451d2e52b24afdbcb00204d3a951b772c3/ruamel_yaml_clib-0.2.15-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:480894aee0b29752560a9de46c0e5f84a82602f2bc5c6cde8db9a345319acfdf", size = 133764, upload-time = "2025-11-16T16:13:43.932Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c7/2480d062281385a2ea4f7cc9476712446e0c548cd74090bff92b4b49e898/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d3b58ab2454b4747442ac76fab66739c72b1e2bb9bd173d7694b9f9dbc9c000", size = 730537, upload-time = "2025-11-16T20:22:52.918Z" },
+    { url = "https://files.pythonhosted.org/packages/75/08/e365ee305367559f57ba6179d836ecc3d31c7d3fdff2a40ebf6c32823a1f/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bfd309b316228acecfa30670c3887dcedf9b7a44ea39e2101e75d2654522acd4", size = 746944, upload-time = "2025-11-16T16:13:45.338Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5c/8b56b08db91e569d0a4fbfa3e492ed2026081bdd7e892f63ba1c88a2f548/ruamel_yaml_clib-0.2.15-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2812ff359ec1f30129b62372e5f22a52936fac13d5d21e70373dbca5d64bb97c", size = 778249, upload-time = "2025-11-16T16:13:46.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1d/70dbda370bd0e1a92942754c873bd28f513da6198127d1736fa98bb2a16f/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7e74ea87307303ba91073b63e67f2c667e93f05a8c63079ee5b7a5c8d0d7b043", size = 737140, upload-time = "2025-11-16T16:13:48.349Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/87/822d95874216922e1120afb9d3fafa795a18fdd0c444f5c4c382f6dac761/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:713cd68af9dfbe0bb588e144a61aad8dcc00ef92a82d2e87183ca662d242f524", size = 741070, upload-time = "2025-11-16T20:22:54.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/17/4e01a602693b572149f92c983c1f25bd608df02c3f5cf50fd1f94e124a59/ruamel_yaml_clib-0.2.15-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:542d77b72786a35563f97069b9379ce762944e67055bea293480f7734b2c7e5e", size = 765882, upload-time = "2025-11-16T16:13:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/17/7999399081d39ebb79e807314de6b611e1d1374458924eb2a489c01fc5ad/ruamel_yaml_clib-0.2.15-cp314-cp314-win32.whl", hash = "sha256:424ead8cef3939d690c4b5c85ef5b52155a231ff8b252961b6516ed7cf05f6aa", size = 102567, upload-time = "2025-11-16T16:13:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/67/be582a7370fdc9e6846c5be4888a530dcadd055eef5b932e0e85c33c7d73/ruamel_yaml_clib-0.2.15-cp314-cp314-win_amd64.whl", hash = "sha256:ac9b8d5fa4bb7fd2917ab5027f60d4234345fd366fe39aa711d5dca090aa1467", size = 122847, upload-time = "2025-11-16T16:13:51.807Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1484,6 +1903,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1514,6 +1942,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/72/c58d84f5704c6caadd9f803a3adad5ab54ac65328c02d13295f40860cf33/testcontainers-4.8.2.tar.gz", hash = "sha256:dd4a6a2ea09e3c3ecd39e180b6548105929d0bb78d665ce9919cb3f8c98f9853", size = 63590, upload-time = "2024-10-14T03:50:19.058Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/77/5ac0dff2903a033d83d971fd85957356abdb66a327f3589df2b3d1a586b4/testcontainers-4.8.2-py3-none-any.whl", hash = "sha256:9e19af077cd96e1957c13ee466f1f32905bc6c5bc1bc98643eb18be1a989bfb0", size = 104326, upload-time = "2024-10-14T03:50:16.957Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]
@@ -1554,6 +2006,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
     { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
     { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -1860,6 +2321,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/4a/b27b182fdf24c9760a91481c6b97d9f536a15f6bc7c33d750eccaa245670/whenever-0.9.5-cp314-cp314t-win32.whl", hash = "sha256:681c9f4d322182df28037a33f0d4eadf7577fcd590130f7a5d23763a86ab5687", size = 417599, upload-time = "2026-01-11T19:47:36.201Z" },
     { url = "https://files.pythonhosted.org/packages/6d/93/712f65c4fc3c188b0c163cd650cb04a46f993a22d1ad3f66a3e4a42a39f8/whenever-0.9.5-cp314-cp314t-win_amd64.whl", hash = "sha256:37242c895078bb1bfc26bea460f6d92dc5bdfe4a59e95a4f9e01f99b90f0157e", size = 440654, upload-time = "2026-01-11T19:47:46.924Z" },
     { url = "https://files.pythonhosted.org/packages/91/fb/1b112af72e5a2b5ac66b5a6a478cc220117224c1481a2b1a35e87222a791/whenever-0.9.5-py3-none-any.whl", hash = "sha256:cc600303e703d57cc42c5db1c81bbc3becb8ef6fde5c46aee5d68c292239fc4b", size = 64873, upload-time = "2026-01-11T19:47:49.585Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds an **opt-in integration test tier** that exercises the MCP server end-to-end against a real, ephemeral Infrahub provisioned via [`infrahub-testcontainers`](https://pypi.org/project/infrahub-testcontainers/). Built through the Spec-Kit flow in `specs/001-infrahub-testcontainers/` (specify → clarify → plan → tasks → implement).

**Scope: MVP — User Story 1 (Phases 1–3).** CI integration job (US2), unit-loop guard (US3), and docs/guideline polish (Phase 6) are follow-ups.

## What's here

- **Suite separation** — new `tests/integration/` + `@pytest.mark.integration`. Default `uv run pytest` stays Docker-free (marker excluded; the two infrahub pytest plugins disabled in `addopts`). Run the suite with `uv run pytest -m integration`.
- **Session harness** (`conftest.py`) — one Infrahub container per session (Docker fail-fast + readiness probe), session seeding of a minimal `Testing` schema, a fresh per-test Infrahub branch for isolation, guaranteed teardown with an `INFRAHUB_TESTCONTAINERS_KEEP` toggle.
- **Drive layer** — the in-process FastMCP `Client` against the server instance. The Starlette ASGI auth/OIDC layer is bypassed (no OIDC container needed) while FastMCP-level middleware — incl. `ReadOnlyMiddleware` write-gating — still runs.
- **Coverage** — schema & branches resources, `get_nodes` (filter + pagination), `query_graphql` (read + mutation rejection), a write tool (branch-safety + read-only gating), a version-compatibility check (FR-013), and failure modes.

## Verification

- ✅ Default unit suite: **328 passed, 18 skipped, 12 deselected** (~1.1s) — fast loop intact (SC-002).
- ✅ Integration tests **collect** cleanly (12 tests, asyncio).
- ✅ CI gates pass locally: `ruff check .`, `ruff format --check .`, `ty check .`, `yamllint` all clean.

## ⚠️ Not yet run against a live Infrahub

The live `uv run pytest -m integration` (Docker) is **deferred** — the suite has not yet executed against a real backend. First-run items to confirm (marked `NOTE(runtime)` in the code):

1. `read_only=true` reload of the server module (read_only is import-time).
2. `node_upsert` session-branch semantics (the test asserts the write is absent on `main`).
3. `get_nodes` `filters={"color__value": ...}` forwarding + pagination result shape.
4. GraphQL plural query shape + mutation rejection.

## Notes

- Also removes a stale `RUF029` `# noqa` in `server.py` that `ruff check .` flagged (1 line).
- **Deviation:** the harness imports the `infrahub_testcontainers` classes directly and does not require the `pytest-infrahub` plugin enabled — simpler than the plan anticipated; both infrahub plugins stay disabled.
- No CI workflow currently runs pytest; the integration CI job is tracked as follow-up T019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in integration test suite that runs the MCP server end-to-end against an ephemeral Infrahub via `infrahub-testcontainers`, and vendors the `opsmill` spec‑kit extension with extract/summary hooks. The suite runs green; the default `pytest` run excludes `-m integration` and disables Infrahub plugins to keep the unit loop Docker‑free.

- **Bug Fixes**
  - Add `display_labels: [name__value]` to the test schema so `get_nodes` returns readable labels; fixes failing assertions.
  - Replace SDK/version check in `test_version_compat` with a container-image check (`INFRAHUB_TESTING_IMAGE_VER` or `infrahub-testcontainers` version); integration suite passes (12/12).
  - Hard-set `INFRAHUB_MCP_READ_ONLY=false` in the test harness to avoid pairing a write-enabled client with a read-only server.

- **Dependencies**
  - Bump dev dependency to `infrahub-testcontainers>=1.10.0`.

<sup>Written for commit 826e6ed9187195ff9677a1a777b4d463c4400d3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-mcp/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

