### PR TITLE
docs: add release notes for v1.0.0 through v1.1.6

### DIFF
--- a/.vale/styles/Infrahub/sentence-case.yml
+++ b/.vale/styles/Infrahub/sentence-case.yml
@@ -70,6 +70,7 @@ exceptions:
   - Open ID Connect
   - OpsMill
   - Proposed Change
+  - Proposed Changes
   - Pydantic
   - Python
   - RabbitMQ

--- a/.vale/styles/brand-names.txt
+++ b/.vale/styles/brand-names.txt
@@ -47,6 +47,7 @@ Opsmill
 Otternet
 Postgress
 Postgresql
+Prometheus
 psutil
 PyPI
 Redoc

--- a/.vale/styles/brand-names.txt
+++ b/.vale/styles/brand-names.txt
@@ -7,6 +7,7 @@ CloudFormation
 Containerlab
 Dagster
 Datadog
+Dependabot
 direnv
 docker
 dockerfile

--- a/.vale/styles/technical-terms.txt
+++ b/.vale/styles/technical-terms.txt
@@ -66,6 +66,7 @@ rebased
 repo
 resources
 REST
+retryable
 sanitization
 Schema
 schema's
@@ -73,6 +74,7 @@ scrollable
 scrollbar
 sdk
 stderr
+stdio
 Streamable
 subprocess
 subcommand

--- a/.vale/styles/technical-terms.txt
+++ b/.vale/styles/technical-terms.txt
@@ -124,3 +124,5 @@ Docstrings
 monorepo
 SDK's
 Speckit's
+auditable
+untrusted

--- a/.vale/styles/technical-terms.txt
+++ b/.vale/styles/technical-terms.txt
@@ -2,6 +2,7 @@ agent
 anonymized
 APIs
 async
+auditable
 backoff
 boolean
 codespace
@@ -84,6 +85,7 @@ traceback
 tracebacks
 triaging
 uncheck
+untrusted
 uplink
 uplinks
 Uplinks
@@ -124,5 +126,3 @@ Docstrings
 monorepo
 SDK's
 Speckit's
-auditable
-untrusted

--- a/docs/docs/release-notes/release-1_0_0.mdx
+++ b/docs/docs/release-notes/release-1_0_0.mdx
@@ -1,0 +1,46 @@
+---
+title: Release 1.0.0
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.0.0</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>March 26th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.0.0](https://github.com/opsmill/infrahub-mcp/releases/tag/v1.0.0)</td>
+    </tr>
+  </tbody>
+</table>
+
+The first stable release of the Infrahub MCP server — a focused, token-efficient interface that lets AI agents read and safely change infrastructure state through Infrahub.
+
+## Highlights
+
+### Six-tool design with branch-isolated writes
+
+- **The problem.** Earlier builds exposed a large, overlapping set of tools and wrote directly against a target branch. An agent had a wide surface to reason about, and any write touched shared state with no review boundary in between.
+- **What this enables.** A minimal six-tool interface, with **schema and branches exposed as MCP resources** instead of tools, and every write automatically routed to a **per-session branch**. An agent's changes land in isolation, ready for a human to review and merge.
+- **When you need it.** Any agent-driven change workflow where edits must stay auditable and reversible before they reach the main branch — see [Safe changes via branch isolation](../use-cases/safe-changes-branch-isolation.mdx).
+
+### Token-efficient responses
+
+- **The problem.** Structured Infrahub results consumed a large share of the model's context window, limiting how much an agent could take in per call.
+- **What this enables.** TOON encoding for structured arrays cuts response size by roughly **33–45%**, alongside broad token-footprint reductions across tools and resources.
+- **When you need it.** Large queries — device inventories, IPAM data, topology — where context budget is the real bottleneck.
+
+## Other changes
+
+#### Added
+
+- Branch support for the GraphQL query tool, so reads and queries can target a specific branch.
+
+#### Changed
+
+- Integration tests migrated to the Anthropic SDK.

--- a/docs/docs/release-notes/release-1_0_0.mdx
+++ b/docs/docs/release-notes/release-1_0_0.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 1.0.0
+description: The first stable release — query Infrahub and propose changes for review from any MCP-compatible client.
 ---
 
 <table>

--- a/docs/docs/release-notes/release-1_0_0.mdx
+++ b/docs/docs/release-notes/release-1_0_0.mdx
@@ -73,9 +73,9 @@ Use `get_schema` when working with MCP clients that do not support resources.
 
 ### Added
 
-* Branch support for GraphQL queries (#32).
+* Branch support for GraphQL queries ([#32](https://github.com/opsmill/infrahub-mcp/pull/32)).
 
 ### Changed
 
-* Exposed schema and branches as MCP resources and adopted a branch-per-session write model (#35).
+* Exposed schema and branches as MCP resources and adopted a branch-per-session write model ([#35](https://github.com/opsmill/infrahub-mcp/pull/35)).
 * Migrated integration tests to the Anthropic SDK.

--- a/docs/docs/release-notes/release-1_0_0.mdx
+++ b/docs/docs/release-notes/release-1_0_0.mdx
@@ -9,6 +9,10 @@ title: Release 1.0.0
       <td>1.0.0</td>
     </tr>
     <tr>
+      <th>Release Type</th>
+      <td>Feature</td>
+    </tr>
+    <tr>
       <th>Release Date</th>
       <td>March 26th, 2026</td>
     </tr>
@@ -19,28 +23,59 @@ title: Release 1.0.0
   </tbody>
 </table>
 
-The first stable release of the Infrahub MCP server — a focused, token-efficient interface that lets AI agents read and safely change infrastructure state through Infrahub.
+## Release summary
 
-## Highlights
+Your AI agents can now gather Infrahub context directly through the MCP server instead of switching between GraphQL queries, the UI, and documentation. This allows AI tools to better understand relationships between objects and safely propose changes for review.
 
-### Six-tool design with branch-isolated writes
+### Query Infrahub data from MCP-compatible clients
 
-- **The problem.** Earlier builds exposed a large, overlapping set of tools and wrote directly against a target branch. An agent had a wide surface to reason about, and any write touched shared state with no review boundary in between.
-- **What this enables.** A minimal six-tool interface, with **schema and branches exposed as MCP resources** instead of tools, and every write automatically routed to a **per-session branch**. An agent's changes land in isolation, ready for a human to review and merge.
-- **When you need it.** Any agent-driven change workflow where edits must stay auditable and reversible before they reach the main branch — see [Safe changes via branch isolation](../use-cases/safe-changes-branch-isolation.mdx).
+Infrahub data is now available to AI agents through the MCP server, making it possible to retrieve objects, search relationships, and execute GraphQL queries from MCP-compatible clients.
 
-### Token-efficient responses
+**What changed**
 
-- **The problem.** Structured Infrahub results consumed a large share of the model's context window, limiting how much an agent could take in per call.
-- **What this enables.** TOON encoding for structured arrays cuts response size by roughly **33–45%**, alongside broad token-footprint reductions across tools and resources.
-- **When you need it.** Large queries — device inventories, IPAM data, topology — where context budget is the real bottleneck.
+* Retrieve infrastructure objects by kind using `get_nodes`, with support for attribute and relationship filters, partial matching, attribute selection, and limit/offset paging to narrow large datasets.
+* Search for infrastructure objects by partial name using `search_nodes`, making it easier to locate objects when only part of an identifier is known.
+* Run GraphQL read queries using `query_graphql` for cases that require more complex data retrieval. Mutations are rejected; write mutations go through `mutate_graphql` on the session branch.
+* Retrieve schema using `get_schema` when working with MCP clients that do not support resources.
+* Check which branch a write will target using `get_session_info`, which reports the active session branch (or `none` before the first write).
 
-## Other changes
+### Help AI understand Infrahub relationships and schema
 
-#### Added
+Schema and branch information are now exposed as MCP resources, allowing AI agents to discover available kinds, attributes, relationships, and branches directly from Infrahub.
 
-- Branch support for the GraphQL query tool, so reads and queries can target a specific branch.
+**What changed**
 
-#### Changed
+* Explore available kinds using `infrahub://schema`, allowing AI agents to discover the Infrahub data model dynamically.
+* Explore attributes, relationships, and filters for a specific kind using `infrahub://schema/{kind}`, making it possible to build queries from the live schema.
+* Access the GraphQL SDL through `infrahub://graphql-schema` when working directly with GraphQL-aware clients.
+* Access branch names, descriptions, and default branch information through `infrahub://branches` to understand the current branch context.
 
-- Integration tests migrated to the Anthropic SDK.
+### Review and merge changes created with AI using existing Infrahub workflows
+
+Changes created with AI are kept separate from the default branch and can be explicitly submitted as a Proposed Change, allowing them to follow the same review and merge process used elsewhere in Infrahub.
+
+**What changed**
+
+* Create a session branch automatically on the first write so changes remain isolated from the default branch.
+* Generate branch names using `INFRAHUB_MCP_BRANCH_PATTERN` to keep branch creation consistent across sessions.
+* Retry branch creation automatically when naming collisions occur.
+* Open a Proposed Change explicitly with `propose_changes`, which records the source and destination branches so reviewers can see exactly where changes will be merged.
+
+## Upgrade notes
+
+### Reading schema and branches
+
+Schema and branch information are available as MCP resources (`infrahub://schema`, `infrahub://branches`).
+
+Use `get_schema` when working with MCP clients that do not support resources.
+
+## Full changelog
+
+### Added
+
+* Branch support for GraphQL queries (#32).
+
+### Changed
+
+* Exposed schema and branches as MCP resources and adopted a branch-per-session write model (#35).
+* Migrated integration tests to the Anthropic SDK.

--- a/docs/docs/release-notes/release-1_0_1.mdx
+++ b/docs/docs/release-notes/release-1_0_1.mdx
@@ -1,0 +1,28 @@
+---
+title: Release 1.0.1
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.0.1</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>April 7th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.0.1](https://github.com/opsmill/infrahub-mcp/releases/tag/v1.0.1)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Added
+
+- MCP error messages now include schema-discovery hints, so when a query references an unknown node or attribute the agent gets a pointer toward the correct schema instead of an opaque failure.
+
+### Fixed
+
+- Resolved a set of Dependabot security alerts and updated affected dependencies.

--- a/docs/docs/release-notes/release-1_0_1.mdx
+++ b/docs/docs/release-notes/release-1_0_1.mdx
@@ -48,4 +48,4 @@ Schema information is now included in common error paths, allowing AI agents to 
 
 ### Added
 
-* Schema discovery hints in MCP error messages (#54).
+* Schema discovery hints in MCP error messages ([#54](https://github.com/opsmill/infrahub-mcp/pull/54)).

--- a/docs/docs/release-notes/release-1_0_1.mdx
+++ b/docs/docs/release-notes/release-1_0_1.mdx
@@ -9,6 +9,10 @@ title: Release 1.0.1
       <td>1.0.1</td>
     </tr>
     <tr>
+      <th>Release Type</th>
+      <td>Improvement</td>
+    </tr>
+    <tr>
       <th>Release Date</th>
       <td>April 7th, 2026</td>
     </tr>
@@ -19,10 +23,29 @@ title: Release 1.0.1
   </tbody>
 </table>
 
+## Release summary
+
+Use AI agents to query Infrahub data without being interrupted by invalid queries. Error messages now provide enough context for AI agents to identify valid alternatives and retry automatically.
+
+### Query Infrahub data without interrupting a conversation to correct invalid queries
+
+Schema information is now included in common error paths, allowing AI agents to correct invalid queries and continue working without manual intervention.
+
+**What changed**
+
+* Return valid kinds when an unknown kind is referenced, making it easier to correct invalid requests.
+* Return valid filters for the requested kind so AI agents can build a corrected query automatically.
+* Include `get_schema` in remediation guidance when additional schema information is needed.
+* Apply the same behavior to read, write, and GraphQL operations.
+
+## Minor changes
+
+### Security
+
+* Updated dependencies, including `ujson`, `requests`, `aiohttp`, and `fastmcp`.
+
+## Full changelog
+
 ### Added
 
-- MCP error messages now include schema-discovery hints, so when a query references an unknown node or attribute the agent gets a pointer toward the correct schema instead of an opaque failure.
-
-### Fixed
-
-- Resolved a set of Dependabot security alerts and updated affected dependencies.
+* Schema discovery hints in MCP error messages (#54).

--- a/docs/docs/release-notes/release-1_0_1.mdx
+++ b/docs/docs/release-notes/release-1_0_1.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 1.0.1
+description: Error messages now include schema hints so AI agents can correct invalid queries and retry.
 ---
 
 <table>

--- a/docs/docs/release-notes/release-1_1_1.mdx
+++ b/docs/docs/release-notes/release-1_1_1.mdx
@@ -1,0 +1,52 @@
+---
+title: Release 1.1.1
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.1.1</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 4th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.1.1](https://github.com/opsmill/infrahub-mcp/releases/tag/v1.1.1)</td>
+    </tr>
+  </tbody>
+</table>
+
+This release turns the MCP server into something you can run in production: a full middleware stack adds authentication, rate limiting, and observability, and a tag-based read-only mode lets you expose the server safely when writes are not wanted.
+
+## Highlights
+
+### Production middleware stack
+
+- **The problem.** The early server had no consistent place to enforce authentication, protect against abusive traffic, or emit the metrics and traces an operator needs to run a service. Each concern, if handled at all, was scattered.
+- **What this enables.** A single middleware stack, composed once at startup, that layers correlation IDs, Prometheus metrics, OpenTelemetry tracing, structured error handling, authentication, and rate limiting around every tool call — each layer wired through configuration so you turn on only what you need.
+- **When you need it.** Running the server as a shared, network-exposed service rather than a local stdio process — when you need it authenticated, observable, and protected from runaway clients. See the [Configuration reference](../references/configuration.mdx).
+
+### Authentication with token passthrough
+
+- **The problem.** A shared MCP server needs every caller to act as themselves in Infrahub, not as a single service identity — otherwise every change is attributed to the server and per-user permissions are lost.
+- **What this enables.** A dual-layer design extracts each request's credentials and passes them through to Infrahub, scoped to that request and reset afterward. Calls without credentials are rejected (fail-closed).
+- **When you need it.** Multi-user deployments where Infrahub's own permissions and audit trail must follow the real user behind each agent. See the [Authentication reference](../references/authentication.mdx).
+
+### Tag-based read-only mode
+
+- **The problem.** Some deployments should never write — read-only analytics, demos, or untrusted agents — but the only guarantee was "don't call the write tools."
+- **What this enables.** Write tools are tagged `write`, and read-only mode disables them with defense-in-depth, so a misbehaving or malicious agent cannot mutate state even if it tries.
+- **When you need it.** Exposing infrastructure data for investigation, reporting, or correlation without granting any ability to change it.
+
+## Other changes
+
+#### Added
+
+- A CI/CD versioning and release process, including automated, categorized release drafts.
+
+#### Notes
+
+- `v1.1.0` was prepared internally but never published; the work above ships to users in `v1.1.1`.

--- a/docs/docs/release-notes/release-1_1_1.mdx
+++ b/docs/docs/release-notes/release-1_1_1.mdx
@@ -85,15 +85,15 @@ If multiple people use a shared deployment, configure `INFRAHUB_MCP_AUTH_MODE` a
 
 ### Added
 
-* Production middleware stack: authentication, rate limiting, observability, read-only mode, and `/health` and `/metrics` endpoints (#62).
+* Production middleware stack: authentication, rate limiting, observability, read-only mode, and `/health` and `/metrics` endpoints ([#62](https://github.com/opsmill/infrahub-mcp/pull/62)).
 
 ### Changed
 
-* Documentation upgraded to Docusaurus 3.10.0 (#65).
+* Documentation upgraded to Docusaurus 3.10.0 ([#65](https://github.com/opsmill/infrahub-mcp/pull/65)).
 
 ### Fixed
 
-* Removed a broken release-drafter workflow (#69).
+* Removed a broken release-drafter workflow ([#69](https://github.com/opsmill/infrahub-mcp/pull/69)).
 
 ## Notes
 

--- a/docs/docs/release-notes/release-1_1_1.mdx
+++ b/docs/docs/release-notes/release-1_1_1.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 1.1.1
+description: Run the MCP server as a shared service with pass-through authentication, read-only mode, and observability.
 ---
 
 <table>

--- a/docs/docs/release-notes/release-1_1_1.mdx
+++ b/docs/docs/release-notes/release-1_1_1.mdx
@@ -9,6 +9,10 @@ title: Release 1.1.1
       <td>1.1.1</td>
     </tr>
     <tr>
+      <th>Release Type</th>
+      <td>Feature</td>
+    </tr>
+    <tr>
       <th>Release Date</th>
       <td>May 4th, 2026</td>
     </tr>
@@ -19,34 +23,78 @@ title: Release 1.1.1
   </tbody>
 </table>
 
-This release turns the MCP server into something you can run in production: a full middleware stack adds authentication, rate limiting, and observability, and a tag-based read-only mode lets you expose the server safely when writes are not wanted.
+## Release summary
 
-## Highlights
+Run the MCP server as a shared service instead of a local process while preserving individual identities, controlling write access, and monitoring server health through dedicated operational endpoints. This makes it practical to deploy a single MCP server for an organization instead of asking each person to install and run their own.
 
-### Production middleware stack
+### Access Infrahub using individual identities
 
-- **The problem.** The early server had no consistent place to enforce authentication, protect against abusive traffic, or emit the metrics and traces an operator needs to run a service. Each concern, if handled at all, was scattered.
-- **What this enables.** A single middleware stack, composed once at startup, that layers correlation IDs, Prometheus metrics, OpenTelemetry tracing, structured error handling, authentication, and rate limiting around every tool call — each layer wired through configuration so you turn on only what you need.
-- **When you need it.** Running the server as a shared, network-exposed service rather than a local stdio process — when you need it authenticated, observable, and protected from runaway clients. See the [Configuration reference](../references/configuration.mdx).
+Authentication can now be passed through to Infrahub so permissions and audit history remain associated with the person making the request instead of a shared service account.
 
-### Authentication with token passthrough
+**What changed**
 
-- **The problem.** A shared MCP server needs every caller to act as themselves in Infrahub, not as a single service identity — otherwise every change is attributed to the server and per-user permissions are lost.
-- **What this enables.** A dual-layer design extracts each request's credentials and passes them through to Infrahub, scoped to that request and reset afterward. Calls without credentials are rejected (fail-closed).
-- **When you need it.** Multi-user deployments where Infrahub's own permissions and audit trail must follow the real user behind each agent. See the [Authentication reference](../references/authentication.mdx).
+* Configure authentication using `none`, `oidc`, `token-passthrough`, or `basic-passthrough`.
+* Pass user tokens through `INFRAHUB_MCP_TOKEN_PASSTHROUGH_HEADER` when using token-based authentication.
+* Pass Infrahub credentials through HTTP basic authentication.
+* Apply passthrough authentication to HTTP transports.
+* Reject unauthenticated requests in passthrough and OIDC modes.
 
-### Tag-based read-only mode
+### Share Infrahub data without enabling writes
 
-- **The problem.** Some deployments should never write — read-only analytics, demos, or untrusted agents — but the only guarantee was "don't call the write tools."
-- **What this enables.** Write tools are tagged `write`, and read-only mode disables them with defense-in-depth, so a misbehaving or malicious agent cannot mutate state even if it tries.
-- **When you need it.** Exposing infrastructure data for investigation, reporting, or correlation without granting any ability to change it.
+Infrahub data can now be exposed in read-only mode, making it possible to investigate, report on, and correlate data across systems without changing state.
 
-## Other changes
+**What changed**
 
-#### Added
+* Remove write-tagged tools by setting `INFRAHUB_MCP_READ_ONLY=true`.
+* Block GraphQL mutations when read-only mode is enabled.
 
-- A CI/CD versioning and release process, including automated, categorized release drafts.
+### Monitor the MCP server like any other service
 
-#### Notes
+Health endpoints, metrics, and middleware are now available so the MCP server can be operated and observed like any other service.
 
-- `v1.1.0` was prepared internally but never published; the work above ships to users in `v1.1.1`.
+**What changed**
+
+* Collect request IDs, Prometheus metrics, OpenTelemetry traces, structured logs, retries, response caching, and rate limiting through middleware.
+* Access `/health` for readiness checks.
+* Access `/metrics` for Prometheus or JSON-based monitoring.
+* Record audit logs for write operations.
+
+## Upgrade notes
+
+### Configure authentication before exposing the server over HTTP
+
+If multiple people use a shared deployment, configure `INFRAHUB_MCP_AUTH_MODE` along with token passthrough or OIDC settings before exposing the server.
+
+`stdio` deployments continue to use environment variable credentials.
+
+## Minor changes
+
+### Documentation
+
+* Upgraded the documentation build to Docusaurus 3.10.0.
+
+### Release pipeline
+
+* Added automated, categorized release drafts.
+
+### Security
+
+* Updated dependencies, including `cryptography`, `authlib`, and `python-multipart`.
+
+## Full changelog
+
+### Added
+
+* Production middleware stack: authentication, rate limiting, observability, read-only mode, and `/health` and `/metrics` endpoints (#62).
+
+### Changed
+
+* Documentation upgraded to Docusaurus 3.10.0 (#65).
+
+### Fixed
+
+* Removed a broken release-drafter workflow (#69).
+
+## Notes
+
+* `v1.1.0` was prepared internally but never published; this work ships in `v1.1.1`.

--- a/docs/docs/release-notes/release-1_1_2.mdx
+++ b/docs/docs/release-notes/release-1_1_2.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 1.1.2
+description: Dependency and internal tooling maintenance, with no changes to tools or runtime behavior.
 ---
 
 <table>

--- a/docs/docs/release-notes/release-1_1_2.mdx
+++ b/docs/docs/release-notes/release-1_1_2.mdx
@@ -42,8 +42,8 @@ Dependency and internal tooling updates only. There are no changes to MCP tools,
 
 ### Changed
 
-* Updated internal developer tooling (Speckit and extensions) and hardened the release and packaging pipeline (#85).
+* Updated internal developer tooling (Speckit and extensions) and hardened the release and packaging pipeline ([#85](https://github.com/opsmill/infrahub-mcp/pull/85)).
 
 ### Security
 
-* Grouped dependency updates (#91, #86).
+* Grouped dependency updates ([#91](https://github.com/opsmill/infrahub-mcp/pull/91), [#86](https://github.com/opsmill/infrahub-mcp/pull/86)).

--- a/docs/docs/release-notes/release-1_1_2.mdx
+++ b/docs/docs/release-notes/release-1_1_2.mdx
@@ -1,0 +1,26 @@
+---
+title: Release 1.1.2
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.1.2</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 4th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.1.2](https://github.com/opsmill/infrahub-mcp/releases/tag/v1.1.2)</td>
+    </tr>
+  </tbody>
+</table>
+
+An internal maintenance release that fixes the packaging and release pipeline. There are no user-facing changes.
+
+### Fixed
+
+- Isolated the `mcp-discovery` tarball extraction and scoped the release auto-bump so packaging steps no longer interfere with one another.

--- a/docs/docs/release-notes/release-1_1_2.mdx
+++ b/docs/docs/release-notes/release-1_1_2.mdx
@@ -9,6 +9,10 @@ title: Release 1.1.2
       <td>1.1.2</td>
     </tr>
     <tr>
+      <th>Release Type</th>
+      <td>Maintenance</td>
+    </tr>
+    <tr>
       <th>Release Date</th>
       <td>May 4th, 2026</td>
     </tr>
@@ -19,8 +23,27 @@ title: Release 1.1.2
   </tbody>
 </table>
 
-An internal maintenance release that fixes the packaging and release pipeline. There are no user-facing changes.
+## Release summary
 
-### Fixed
+Dependency and internal tooling updates only. There are no changes to MCP tools, workflows, or runtime behavior.
 
-- Isolated the `mcp-discovery` tarball extraction and scoped the release auto-bump so packaging steps no longer interfere with one another.
+## Minor changes
+
+### Developer experience
+
+* Updated Speckit and related extensions.
+* Hardened the release and packaging pipeline.
+
+### Security
+
+* Updated `urllib3` and `python-multipart`.
+
+## Full changelog
+
+### Changed
+
+* Updated internal developer tooling (Speckit and extensions) and hardened the release and packaging pipeline (#85).
+
+### Security
+
+* Grouped dependency updates (#91, #86).

--- a/docs/docs/release-notes/release-1_1_3.mdx
+++ b/docs/docs/release-notes/release-1_1_3.mdx
@@ -1,0 +1,28 @@
+---
+title: Release 1.1.3
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.1.3</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 12th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.1.3](https://github.com/opsmill/infrahub-mcp/releases/tag/v1.1.3)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- The server now passes `host` and `port` to the runner only for the `streamable-http` transport, fixing startup for other transports.
+
+### Changed
+
+- Refreshed internal developer tooling (Speckit and its extensions) and the release pipeline. No runtime behavior changes.

--- a/docs/docs/release-notes/release-1_1_3.mdx
+++ b/docs/docs/release-notes/release-1_1_3.mdx
@@ -49,8 +49,8 @@ Host and port settings are now applied only to the `streamable-http` transport, 
 
 ### Fixed
 
-* Startup now works correctly for non-HTTP transports (#90).
-* Corrected the release auto-labeling pipeline (#94).
+* Startup now works correctly for non-HTTP transports ([#90](https://github.com/opsmill/infrahub-mcp/pull/90)).
+* Corrected the release auto-labeling pipeline ([#94](https://github.com/opsmill/infrahub-mcp/pull/94)).
 
 ### Changed
 

--- a/docs/docs/release-notes/release-1_1_3.mdx
+++ b/docs/docs/release-notes/release-1_1_3.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 1.1.3
+description: Fix startup for non-HTTP transports, plus pipeline and tooling maintenance.
 ---
 
 <table>

--- a/docs/docs/release-notes/release-1_1_3.mdx
+++ b/docs/docs/release-notes/release-1_1_3.mdx
@@ -9,6 +9,10 @@ title: Release 1.1.3
       <td>1.1.3</td>
     </tr>
     <tr>
+      <th>Release Type</th>
+      <td>Improvement</td>
+    </tr>
+    <tr>
       <th>Release Date</th>
       <td>May 12th, 2026</td>
     </tr>
@@ -19,10 +23,35 @@ title: Release 1.1.3
   </tbody>
 </table>
 
+## Release summary
+
+Run non-HTTP transports without additional startup configuration. This also includes pipeline and developer tooling maintenance.
+
+### Run non-HTTP transports correctly
+
+Host and port settings are now applied only to the `streamable-http` transport, allowing other transports to start correctly without additional configuration.
+
+**What changed**
+
+* Pass host and port to the runner only when using `streamable-http`.
+
+## Minor changes
+
+### Release pipeline
+
+* Corrected the release auto-labeling pipeline.
+
+### Developer experience
+
+* Refreshed Speckit and related extensions. No runtime behavior changed.
+
+## Full changelog
+
 ### Fixed
 
-- The server now passes `host` and `port` to the runner only for the `streamable-http` transport, fixing startup for other transports.
+* Startup now works correctly for non-HTTP transports (#90).
+* Corrected the release auto-labeling pipeline (#94).
 
 ### Changed
 
-- Refreshed internal developer tooling (Speckit and its extensions) and the release pipeline. No runtime behavior changes.
+* Refreshed internal developer tooling (Speckit and extensions).

--- a/docs/docs/release-notes/release-1_1_4.mdx
+++ b/docs/docs/release-notes/release-1_1_4.mdx
@@ -42,8 +42,8 @@ Alignment with current Infrahub SDK releases, plus routine dependency maintenanc
 
 ### Changed
 
-* Raised the Infrahub SDK floor to `>=1.20.0` and migrated a deprecated SDK keyword argument (#96).
+* Raised the Infrahub SDK floor to `>=1.20.0` and migrated a deprecated SDK keyword argument ([#96](https://github.com/opsmill/infrahub-mcp/pull/96)).
 
 ### Security
 
-* Grouped dependency and GitHub Actions updates (#98, #97).
+* Grouped dependency and GitHub Actions updates ([#98](https://github.com/opsmill/infrahub-mcp/pull/98), [#97](https://github.com/opsmill/infrahub-mcp/pull/97)).

--- a/docs/docs/release-notes/release-1_1_4.mdx
+++ b/docs/docs/release-notes/release-1_1_4.mdx
@@ -1,0 +1,25 @@
+---
+title: Release 1.1.4
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.1.4</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 12th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.1.4](https://github.com/opsmill/infrahub-mcp/releases/tag/v1.1.4)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Changed
+
+- Bumped the Infrahub SDK floor to `>=1.20.0` and migrated a deprecated SDK keyword argument, keeping the server aligned with current Infrahub releases.
+- Routine dependency updates.

--- a/docs/docs/release-notes/release-1_1_4.mdx
+++ b/docs/docs/release-notes/release-1_1_4.mdx
@@ -43,7 +43,7 @@ Alignment with current Infrahub SDK releases, plus routine dependency maintenanc
 
 ### Changed
 
-* Raised the Infrahub SDK floor to `>=1.20.0` and migrated a deprecated SDK keyword argument ([#96](https://github.com/opsmill/infrahub-mcp/pull/96)).
+* Raised the Infrahub SDK minimum version to `>=1.20.0` and migrated a deprecated SDK keyword argument ([#96](https://github.com/opsmill/infrahub-mcp/pull/96)).
 
 ### Security
 

--- a/docs/docs/release-notes/release-1_1_4.mdx
+++ b/docs/docs/release-notes/release-1_1_4.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 1.1.4
+description: Align with current Infrahub SDK releases, plus routine dependency maintenance.
 ---
 
 <table>

--- a/docs/docs/release-notes/release-1_1_4.mdx
+++ b/docs/docs/release-notes/release-1_1_4.mdx
@@ -9,6 +9,10 @@ title: Release 1.1.4
       <td>1.1.4</td>
     </tr>
     <tr>
+      <th>Release Type</th>
+      <td>Maintenance</td>
+    </tr>
+    <tr>
       <th>Release Date</th>
       <td>May 12th, 2026</td>
     </tr>
@@ -19,7 +23,27 @@ title: Release 1.1.4
   </tbody>
 </table>
 
+## Release summary
+
+Alignment with current Infrahub SDK releases, plus routine dependency maintenance. There are no changes to MCP tools, workflows, or runtime behavior.
+
+## Minor changes
+
+### SDK compatibility
+
+* Raised the Infrahub SDK minimum version to `>=1.20.0`.
+* Migrated a deprecated SDK keyword argument.
+
+### Security
+
+* Updated dependencies and GitHub Actions.
+
+## Full changelog
+
 ### Changed
 
-- Bumped the Infrahub SDK floor to `>=1.20.0` and migrated a deprecated SDK keyword argument, keeping the server aligned with current Infrahub releases.
-- Routine dependency updates.
+* Raised the Infrahub SDK floor to `>=1.20.0` and migrated a deprecated SDK keyword argument (#96).
+
+### Security
+
+* Grouped dependency and GitHub Actions updates (#98, #97).

--- a/docs/docs/release-notes/release-1_1_5.mdx
+++ b/docs/docs/release-notes/release-1_1_5.mdx
@@ -9,6 +9,10 @@ title: Release 1.1.5
       <td>1.1.5</td>
     </tr>
     <tr>
+      <th>Release Type</th>
+      <td>Improvement</td>
+    </tr>
+    <tr>
       <th>Release Date</th>
       <td>May 29th, 2026</td>
     </tr>
@@ -19,10 +23,32 @@ title: Release 1.1.5
   </tbody>
 </table>
 
+## Release summary
+
+Know immediately when a session branch can no longer be used. Branch state is validated before reuse, making long-running sessions more predictable and laying the groundwork for the automatic recovery in [1.1.6](./release-1_1_6.mdx).
+
+### Get a clear signal when a session branch can no longer be used
+
+Branch state is now validated before reuse, so a session whose branch has been merged or deleted fails with a clear reason instead of an opaque error. This is the groundwork for the automatic recovery in [1.1.6](./release-1_1_6.mdx).
+
+**What changed**
+
+* Detect when a cached branch has been deleted.
+* Detect when a cached branch has already been merged or is being deleted.
+* Report why a branch can no longer be used before attempting additional writes.
+
+## Minor changes
+
+### Documentation
+
+* Updated the README.
+
+### Security
+
+* Updated dependencies, including `idna` and `authlib`.
+
+## Full changelog
+
 ### Fixed
 
-- The server now validates a cached session branch before reusing it, so a session whose branch is no longer usable fails clearly instead of writing against a stale branch. This lays the groundwork for the automatic session-branch recovery that follows in [1.1.6](./release-1_1_6.mdx).
-
-### Changed
-
-- Routine dependency updates.
+* Validate the cached session branch before reuse (#110).

--- a/docs/docs/release-notes/release-1_1_5.mdx
+++ b/docs/docs/release-notes/release-1_1_5.mdx
@@ -21,7 +21,7 @@ title: Release 1.1.5
 
 ### Fixed
 
-- The server now validates a cached session branch before reusing it, so a session whose branch is no longer usable fails clearly instead of writing against a stale branch. This is the groundwork for the automatic recovery introduced in [1.1.6](./release-1_1_6.mdx).
+- The server now validates a cached session branch before reusing it, so a session whose branch is no longer usable fails clearly instead of writing against a stale branch. This lays the groundwork for the automatic session-branch recovery that follows in [1.1.6](./release-1_1_6.mdx).
 
 ### Changed
 

--- a/docs/docs/release-notes/release-1_1_5.mdx
+++ b/docs/docs/release-notes/release-1_1_5.mdx
@@ -53,3 +53,7 @@ Branch state is now validated before reuse, so a session whose branch has been m
 ### Fixed
 
 * Validate the cached session branch before reuse ([#110](https://github.com/opsmill/infrahub-mcp/pull/110)).
+
+### Security
+
+* Updated dependencies, including `idna` ([#105](https://github.com/opsmill/infrahub-mcp/pull/105)) and `authlib` ([#103](https://github.com/opsmill/infrahub-mcp/pull/103)).

--- a/docs/docs/release-notes/release-1_1_5.mdx
+++ b/docs/docs/release-notes/release-1_1_5.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 1.1.5
+description: Validate a session branch before reuse so an unusable branch fails with a clear reason.
 ---
 
 <table>

--- a/docs/docs/release-notes/release-1_1_5.mdx
+++ b/docs/docs/release-notes/release-1_1_5.mdx
@@ -51,4 +51,4 @@ Branch state is now validated before reuse, so a session whose branch has been m
 
 ### Fixed
 
-* Validate the cached session branch before reuse (#110).
+* Validate the cached session branch before reuse ([#110](https://github.com/opsmill/infrahub-mcp/pull/110)).

--- a/docs/docs/release-notes/release-1_1_5.mdx
+++ b/docs/docs/release-notes/release-1_1_5.mdx
@@ -1,0 +1,28 @@
+---
+title: Release 1.1.5
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.1.5</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 29th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.1.5](https://github.com/opsmill/infrahub-mcp/releases/tag/v1.1.5)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- The server now validates a cached session branch before reusing it, so a session whose branch is no longer usable fails clearly instead of writing against a stale branch. This is the groundwork for the automatic recovery introduced in [1.1.6](./release-1_1_6.mdx).
+
+### Changed
+
+- Routine dependency updates.

--- a/docs/docs/release-notes/release-1_1_6.mdx
+++ b/docs/docs/release-notes/release-1_1_6.mdx
@@ -62,13 +62,13 @@ Changes created with AI are kept separate from the default branch and can be exp
 
 ### Added
 
-* `reset_session_branch` tool to reset or switch the session branch (#114).
+* `reset_session_branch` tool to reset or switch the session branch ([#114](https://github.com/opsmill/infrahub-mcp/pull/114)).
 
 ### Changed
 
-* `search_nodes` now uses `any__value` with `partial_match`, making substring searches consistent across concrete and abstract kinds (#93).
-* Writes always target the active session branch, and privileged branch and schema mutations are blocked (#114).
+* `search_nodes` now uses `any__value` with `partial_match`, making substring searches consistent across concrete and abstract kinds ([#93](https://github.com/opsmill/infrahub-mcp/pull/93)).
+* Writes always target the active session branch, and privileged branch and schema mutations are blocked ([#114](https://github.com/opsmill/infrahub-mcp/pull/114)).
 
 ### Fixed
 
-* Recover stale (merged or deleted) session branches automatically (#114).
+* Recover stale (merged or deleted) session branches automatically ([#114](https://github.com/opsmill/infrahub-mcp/pull/114)).

--- a/docs/docs/release-notes/release-1_1_6.mdx
+++ b/docs/docs/release-notes/release-1_1_6.mdx
@@ -1,0 +1,36 @@
+---
+title: Release 1.1.6
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.1.6</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>June 8th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.1.6](https://github.com/opsmill/infrahub-mcp/releases/tag/v1.1.6)</td>
+    </tr>
+  </tbody>
+</table>
+
+This release makes per-session branches resilient: the server now recovers automatically when a session's branch has been merged or deleted, adds a tool to reset or switch branches on demand, and hardens writes against races.
+
+## Highlights
+
+### Session-branch recovery and reset
+
+- **The problem.** A session's working branch could disappear underneath it — merged by a reviewer or deleted — and the next write would fail against a branch that no longer accepted changes, with no clean way to recover.
+- **What this enables.** The server now detects a merged or deleted session branch and provisions a fresh one automatically, telling the caller both the old and new branch names. A new write-tagged `reset_session_branch` tool lets an agent start a clean branch or switch to a named one explicitly. Writes are also hardened against the race where a branch is merged mid-operation, confirming the branch is genuinely stale before clearing it so in-flight work is never orphaned.
+- **When you need it.** Long-running or multi-turn agent sessions where branches are reviewed and merged while the agent is still working — see [Safe changes via branch isolation](../use-cases/safe-changes-branch-isolation.mdx).
+
+## Other changes
+
+#### Fixed
+
+- `search_nodes` now uses `any__value` with partial matching, so substring searches return the results you expect.

--- a/docs/docs/release-notes/release-1_1_6.mdx
+++ b/docs/docs/release-notes/release-1_1_6.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.1.6
-description: Continue an AI session across multiple Proposed Changes, with automatic session-branch recovery and a reset tool.
+description: Continue an AI conversation across multiple Proposed Changes, with automatic session branch recovery and a reset tool.
 ---
 
 <table>

--- a/docs/docs/release-notes/release-1_1_6.mdx
+++ b/docs/docs/release-notes/release-1_1_6.mdx
@@ -9,6 +9,10 @@ title: Release 1.1.6
       <td>1.1.6</td>
     </tr>
     <tr>
+      <th>Release Type</th>
+      <td>Feature</td>
+    </tr>
+    <tr>
       <th>Release Date</th>
       <td>June 8th, 2026</td>
     </tr>
@@ -19,18 +23,52 @@ title: Release 1.1.6
   </tbody>
 </table>
 
-This release makes per-session branches resilient: the server now recovers automatically when a session's branch has been merged or deleted, adds a tool to reset or switch branches on demand, and hardens writes against races.
+## Release summary
 
-## Highlights
+Continue using AI across multiple Proposed Changes without starting over. When a Proposed Change has been merged or its branch is no longer available, work can continue in the same session while still following existing Infrahub review workflows.
 
-### Session-branch recovery and reset
+### Continue using AI after a Proposed Change has been merged
 
-- **The problem.** A session's working branch could disappear underneath it — merged by a reviewer or deleted — and the next write would fail against a branch that no longer accepted changes, with no clean way to recover.
-- **What this enables.** The server now detects a merged or deleted session branch and provisions a fresh one automatically, telling the caller both the old and new branch names. A new write-tagged `reset_session_branch` tool lets an agent start a clean branch or switch to a named one explicitly. Writes are also hardened against the race where a branch is merged mid-operation, confirming the branch is genuinely stale before clearing it so in-flight work is never orphaned.
-- **When you need it.** Long-running or multi-turn agent sessions where branches are reviewed and merged while the agent is still working — see [Safe changes via branch isolation](../use-cases/safe-changes-branch-isolation.mdx).
+When a Proposed Change has been merged or its branch is no longer available, a replacement branch is created automatically so work can continue in the same session.
 
-## Other changes
+**What changed**
 
-#### Fixed
+* Detect when a branch has been deleted, merged, or is in the process of being deleted.
+* Create a replacement branch automatically when the current branch can no longer accept changes.
+* Surface a retryable error when a branch changes state mid-write — the failed write is not replayed automatically (a partial mutation could apply), so the next attempt runs on a fresh branch.
 
-- `search_nodes` now uses `any__value` with partial matching, so substring searches return the results you expect.
+### Start fresh or switch to a different branch
+
+A session branch can now be reset or changed explicitly, making it easier to start over or continue work on a branch that was prepared ahead of time.
+
+**What changed**
+
+* Reset the current branch using `reset_session_branch()` so the next write starts with a new branch.
+* Switch to a branch by name using `reset_session_branch(<branch-name>)` — created automatically if it does not exist and matches the configured branch pattern.
+* Validate branch names against the configured branch pattern.
+* Reject the default branch and merged or deleting branches.
+
+### Review and merge changes created with AI using existing Infrahub workflows
+
+Changes created with AI are kept separate from the default branch and can be explicitly submitted as a Proposed Change, allowing them to follow the same review and merge process used elsewhere in Infrahub.
+
+**What changed**
+
+* Always write to the active session branch.
+* Block branch and schema mutations, including those nested in GraphQL fragments.
+* Continue using `propose_changes` to submit changes for review.
+
+## Full changelog
+
+### Added
+
+* `reset_session_branch` tool to reset or switch the session branch (#114).
+
+### Changed
+
+* `search_nodes` now uses `any__value` with `partial_match`, making substring searches consistent across concrete and abstract kinds (#93).
+* Writes always target the active session branch, and privileged branch and schema mutations are blocked (#114).
+
+### Fixed
+
+* Recover stale (merged or deleted) session branches automatically (#114).

--- a/docs/docs/release-notes/release-1_1_6.mdx
+++ b/docs/docs/release-notes/release-1_1_6.mdx
@@ -1,5 +1,6 @@
 ---
 title: Release 1.1.6
+description: Continue an AI session across multiple Proposed Changes, with automatic session-branch recovery and a reset tool.
 ---
 
 <table>
@@ -25,9 +26,9 @@ title: Release 1.1.6
 
 ## Release summary
 
-Continue using AI across multiple Proposed Changes without starting over. When a Proposed Change has been merged or its branch is no longer available, work can continue in the same session while still following existing Infrahub review workflows.
+Use the same AI conversation across multiple Proposed Changes instead of starting over after each one. When a Proposed Change has been merged or its branch is no longer available, work can continue in the same session while still following existing Infrahub review workflows.
 
-### Continue using AI after a Proposed Change has been merged
+### Work across multiple Proposed Changes in the same AI conversation
 
 When a Proposed Change has been merged or its branch is no longer available, a replacement branch is created automatically so work can continue in the same session.
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -53,6 +53,26 @@ const sidebars: SidebarsConfig = {
         'references/methods',
       ],
     },
+    {
+      type: 'category',
+      label: 'Release Notes',
+      collapsible: true,
+      collapsed: true,
+      link: {
+        type: 'generated-index',
+        slug: 'release-notes',
+      },
+      items: [
+        'release-notes/release-1_1_6',
+        'release-notes/release-1_1_5',
+        'release-notes/release-1_1_4',
+        'release-notes/release-1_1_3',
+        'release-notes/release-1_1_2',
+        'release-notes/release-1_1_1',
+        'release-notes/release-1_0_1',
+        'release-notes/release-1_0_0',
+      ],
+    },
   ]
 };
 


### PR DESCRIPTION
## Summary

Back-fills curated, user-facing release notes for every published release since 1.0.0, so users and evaluators can understand what each version delivered and *why it matters* — not just a raw commit list. Mirrors the format used in the main `infrahub` docs.

## Key Changes

- New **Release Notes** section in the docs site covering **v1.0.0 → v1.1.6** (8 releases).
- Feature releases (`1.0.0`, `1.1.1`, `1.1.6`) frame each highlight as **the problem → what it enables → when you need it**.
- Patch releases use terse `Added` / `Changed` / `Fixed` sections.
- Metadata table + GitHub tag links per release; wired into a new collapsible sidebar category with a generated index page.

## Related Context

Content sourced from the repo's ADRs (0002–0007), the two archived specs (`production-ready-mcp-server`, `session-branch-recovery`), and the git history between tags.

Note: `v1.1.0` was bumped internally but never published — its work (the production middleware stack) ships to users in `v1.1.1` and is documented there.

## Documentation Updates

- `docs/docs/release-notes/release-1_0_0.mdx` … `release-1_1_6.mdx` (8 new pages)
- `docs/sidebars.ts` — new "Release Notes" category

## Test Plan

- `cd docs && npm run build` — passes; all 8 pages + the generated index render with no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds curated release notes for v1.0.0–v1.1.6 and adds a Release Notes section in the docs. Also adds index card descriptions, links PR references, and updates Vale rules so style checks pass.

- **Documentation**
  - 8 new release pages using the `infrahub` format with metadata tables (includes “Release Type”) and tag + PR links.
  - New collapsible “Release Notes” sidebar with a generated index; index cards use frontmatter descriptions.
  - Accuracy fixes across pages: 1.0.0 (`get_session_info`, `query_graphql`); 1.1.1 (unpublished `v1.1.0` note and auth rejection scope); 1.1.5 (forward-reference wording and added missing Security entries for `idna` and `authlib`); 1.1.6 (summary wording aligned, mid-write recovery clarified, `reset_session_branch` behavior); 1.1.4 uses “minimum version” for the SDK constraint.
  - Vale updates and alphabetized vocabulary: brand/technical terms (`Dependabot`, `Prometheus`, `auditable`, `retryable`, `stdio`, `untrusted`) and sentence-case exceptions add “Proposed Changes”.

<sup>Written for commit 0f824d7234277ffda0feaf5a4891baa053baea57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/opsmill/infrahub-mcp/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

