### PR TITLE
docs: reframe 1.1.6 release note around session-branch recovery

### DIFF
--- a/docs/docs/release-notes/release-1_1_6.mdx
+++ b/docs/docs/release-notes/release-1_1_6.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.1.6
-description: Continue an AI conversation across multiple Proposed Changes, with automatic session branch recovery and a reset tool.
+description: Keep an AI conversation going after its session branch is merged or deleted, with automatic recovery and a reset tool to start the next change set.
 ---
 
 <table>
@@ -26,9 +26,9 @@ description: Continue an AI conversation across multiple Proposed Changes, with 
 
 ## Release summary
 
-Use the same AI conversation across multiple Proposed Changes instead of starting over after each one. When a Proposed Change has been merged or its branch is no longer available, work can continue in the same session while still following existing Infrahub review workflows.
+A session works on a single branch and opens one Proposed Change from it. When that branch is merged or is no longer available, the session recovers automatically so work can continue on a fresh branch, and you can reset or switch branches explicitly to start the next change set — all while still following existing Infrahub review workflows.
 
-### Work across multiple Proposed Changes in the same AI conversation
+### Continue a session after its branch is merged or deleted
 
 When a Proposed Change has been merged or its branch is no longer available, a replacement branch is created automatically so work can continue in the same session.
 


### PR DESCRIPTION
## Problem

The 1.1.6 release note leads with **"Work across multiple Proposed Changes in the same AI conversation."** Reviewing the release announcement, that framing reads as if a single conversation juggles several Proposed Changes, which isn't how it works.

## What the code actually does

A session has **one active session branch** (lazily created on first write); all writes target it, and `propose_changes` opens **one** `CoreProposedChange` from it. `propose_changes` leaves the branch active, so further writes land in the **same** Proposed Change. What 1.1.6 adds is:

- **Automatic recovery** — when the session branch is merged/deleted, the next write provisions a fresh one (`recover_if_session_branch_stale`, PR #114).
- **`reset_session_branch`** — explicitly reset/switch to start the next change set.

So a session can move on to a new Proposed Change **sequentially** (after the current one merges), never several at once.

## Change

Reframe only the **title description, release summary, and section heading** to lead with recovery/reset instead of "multiple Proposed Changes." No behavior, "What changed" bullets, or changelog entries are touched — and the feature docs (`references/methods`, `use-cases/safe-changes-branch-isolation`, `use-cases/brownfield-onboarding`) already describe this model correctly, so they need no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)